### PR TITLE
Shop offers weren't properly inserted

### DIFF
--- a/misc/update_data.go
+++ b/misc/update_data.go
@@ -223,18 +223,16 @@ func importShopOffers(region string, tx *gorm.DB) error {
 	for decoder.More() {
 		var offer struct { // decoding to json via a pq.Int64Array is not supported, so we need to decode the effects manually
 			orm.ShopOffer
-			Effects_ []uint32 `json:"effects" gorm:"-"`
+			Effects_ []uint32 `json:"effect_args" gorm:"-"`
 		}
 		if err := decoder.Decode(&offer); err != nil {
 			return err
 		}
-
 		// Manually convert the effects to pq.Int64Array
 		offer.ShopOffer.Effects = make([]int64, len(offer.Effects_))
 		for i, effect := range offer.Effects_ {
 			offer.ShopOffer.Effects[i] = int64(effect)
 		}
-
 		shopOffer := orm.ShopOffer{
 			ID:             offer.ID,
 			Effects:        offer.Effects,


### PR DESCRIPTION
The [shop_template.json](https://github.com/ggmolly/belfast-data/blob/08affd7104a9c11ab4083d6c5224b7c7725fc67d/EN/shop_template.json) contains an array of shop offers, inside of each shop offers is a `effect_args` key, which represents the 'product' of the purchase. Effects weren't properly decoded due to a typo in the anonymous struct's definition `effect` -> `effect_args`