### PR TITLE
Add CS_10018 and SC_10019 to dissection tool

### DIFF
--- a/misc/proto_to_json.go
+++ b/misc/proto_to_json.go
@@ -12,7 +12,7 @@ func ProtoToJson(packetId int, data *[]byte) (string, error) {
 	var err error
 	var output []byte
 	switch packetId {
-    case 64007:
+	case 64007:
 		var p protobuf.CS_64007
 		if err = proto.Unmarshal(*data, &p); err != nil {
 			return "", err
@@ -5382,6 +5382,18 @@ func ProtoToJson(packetId int, data *[]byte) (string, error) {
 			return "", err
 		}
 		output, err = json.MarshalIndent(p, "", "	")
+	case 10018:
+		var p protobuf.CS_10018
+		if err = proto.Unmarshal(*data, &p); err != nil {
+			return "", err
 		}
+		output, err = json.MarshalIndent(p, "", "	")
+	case 10019:
+		var p protobuf.SC_10019
+		if err = proto.Unmarshal(*data, &p); err != nil {
+			return "", err
+		}
+		output, err = json.MarshalIndent(p, "", "	")
+	}
 	return string(output), err
 }


### PR DESCRIPTION
Very simple fix so that CS_10018 and SC_10019 can be properly shown as JSON in the debug page of the web server.
(Also yes I agree that the massive switch case is stupid, but so is the way of life with protobufs 🙃)