### PR TITLE
fix(packets): stub instagram range response

### DIFF
--- a/cmd/belfast/main.go
+++ b/cmd/belfast/main.go
@@ -243,6 +243,7 @@ func init() {
 	packets.RegisterPacketHandler(22304, []packets.PacketHandler{answer.CommanderManualGetPtAward})
 
 	// Juustagram
+	packets.RegisterPacketHandler(11705, []packets.PacketHandler{answer.InstagramMessageRange})
 	packets.RegisterPacketHandler(11710, []packets.PacketHandler{answer.JuustagramData})
 	packets.RegisterPacketHandler(11720, []packets.PacketHandler{answer.JuustagramReadTip})
 

--- a/internal/answer/instagram_message_range.go
+++ b/internal/answer/instagram_message_range.go
@@ -1,0 +1,19 @@
+package answer
+
+import (
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func InstagramMessageRange(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var payload protobuf.CS_11705
+	if err := proto.Unmarshal(*buffer, &payload); err != nil {
+		return 0, 11706, err
+	}
+
+	response := protobuf.SC_11706{
+		InsMessageList: []*protobuf.INS_MESSAGE{},
+	}
+	return client.SendMessage(11706, &response)
+}


### PR DESCRIPTION
# Summary
- add a CS_11705 handler that returns an empty Instagram message list
- register the handler so packet 11705 is no longer missing

# Changes
- add `InstagramMessageRange` handler for CS_11705 -> SC_11706
- wire packet 11705 to the new handler in server init
