### PR TITLE
feat(packets): implement version check handler

### DIFF
--- a/internal/answer/version_check.go
+++ b/internal/answer/version_check.go
@@ -1,0 +1,77 @@
+package answer
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/consts"
+	"github.com/ggmolly/belfast/internal/misc"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"github.com/ggmolly/belfast/internal/region"
+	"google.golang.org/protobuf/proto"
+)
+
+func VersionCheck(buffer *[]byte, client *connection.Client) (int, int, error) {
+	const responseID = 10997
+	var versionCheck protobuf.CS_10996
+	err := proto.Unmarshal(*buffer, &versionCheck)
+	if err != nil {
+		return 0, responseID, err
+	}
+
+	belfastRegion := region.Current()
+	versionString, err := misc.ResolveRegionVersion(belfastRegion)
+	if err != nil {
+		return 0, responseID, err
+	}
+
+	versionParts, err := parseVersionParts(versionString)
+	if err != nil {
+		return 0, responseID, err
+	}
+
+	url, ok := consts.GamePlatformUrl[belfastRegion][versionCheck.GetPlatform()]
+	if !ok {
+		resolvedPlatform, ok := platformMap[versionCheck.GetPlatform()]
+		if !ok {
+			resolvedPlatform = "Unknown"
+		}
+		return 0, responseID, fmt.Errorf("unknown platform '%s' (id='%s')", resolvedPlatform, versionCheck.GetPlatform())
+	}
+
+	response := protobuf.SC_10997{
+		Version1:    proto.Uint32(versionParts[0]),
+		Version2:    proto.Uint32(versionParts[1]),
+		Version3:    proto.Uint32(versionParts[2]),
+		Version4:    proto.Uint32(versionParts[3]),
+		GatewayIp:   proto.String(consts.RegionGateways[belfastRegion]),
+		GatewayPort: proto.Uint32(80),
+		Url:         proto.String(url),
+	}
+
+	return client.SendMessage(responseID, &response)
+}
+
+func parseVersionParts(version string) ([4]uint32, error) {
+	var parts [4]uint32
+	if version == "" {
+		return parts, fmt.Errorf("empty version")
+	}
+
+	segments := strings.Split(version, ".")
+	if len(segments) < 3 || len(segments) > 4 {
+		return parts, fmt.Errorf("invalid version format %q", version)
+	}
+
+	for i, segment := range segments {
+		value, err := strconv.ParseUint(segment, 10, 32)
+		if err != nil {
+			return parts, fmt.Errorf("invalid version segment %q in %q", segment, version)
+		}
+		parts[i] = uint32(value)
+	}
+
+	return parts, nil
+}

--- a/internal/entrypoint/packet_registry.go
+++ b/internal/entrypoint/packet_registry.go
@@ -112,6 +112,7 @@ func registerPackets() {
 	packets.RegisterPacketHandler(15008, []packets.PacketHandler{answer.SellItem})
 	packets.RegisterPacketHandler(33000, []packets.PacketHandler{answer.WorldCheckInfo})
 	packets.RegisterPacketHandler(10994, []packets.PacketHandler{answer.CheaterMark})
+	packets.RegisterPacketHandler(10996, []packets.PacketHandler{answer.VersionCheck})
 	packets.RegisterPacketHandler(29001, []packets.PacketHandler{answer.NewEducateRequest})
 	packets.RegisterPacketHandler(29003, []packets.PacketHandler{answer.NewEducateGetEndings})
 	packets.RegisterPacketHandler(29005, []packets.PacketHandler{answer.NewEducateSelectEnding})

--- a/internal/misc/version_data.go
+++ b/internal/misc/version_data.go
@@ -1,0 +1,52 @@
+package misc
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+)
+
+var (
+	localVersionsOnce sync.Once
+	localVersions     map[string]string
+	localVersionsErr  error
+)
+
+func ResolveRegionVersion(region string) (string, error) {
+	versions := GetLatestVersions()
+	if versions != nil {
+		if entry, ok := versions[region]; ok {
+			return entry.Version, nil
+		}
+	}
+
+	local, err := loadLocalVersions()
+	if err != nil {
+		return "", err
+	}
+
+	version, ok := local[region]
+	if !ok {
+		return "", fmt.Errorf("missing version for region %q", region)
+	}
+
+	return version, nil
+}
+
+func loadLocalVersions() (map[string]string, error) {
+	localVersionsOnce.Do(func() {
+		file, err := os.Open("belfast-data/versions.json")
+		if err != nil {
+			localVersionsErr = err
+			return
+		}
+		defer file.Close()
+		decoder := json.NewDecoder(file)
+		if err := decoder.Decode(&localVersions); err != nil {
+			localVersionsErr = err
+		}
+	})
+
+	return localVersions, localVersionsErr
+}


### PR DESCRIPTION
# Summary
- Adds CS_10996 handler to return gateway/version info for clients.
- Resolves region version data with a local fallback to build SC_10997 responses.
- Covers success and error paths with handler tests.

# Changes
- Implement VersionCheck handler and register packet 10996.
- Add region version resolver helper and parsing logic.
- Extend handler test suite for CS_10996 responses and errors.
