### PR TITLE
feat(activity): add activity fleet persistence

### DIFF
--- a/internal/answer/activities.go
+++ b/internal/answer/activities.go
@@ -33,6 +33,13 @@ func Activities(buffer *[]byte, client *connection.Client) (int, int, error) {
 		if info == nil {
 			continue
 		}
+		groups, found, err := orm.LoadActivityFleetGroups(client.Commander.CommanderID, template.ID)
+		if err != nil {
+			return 0, 11200, err
+		}
+		if found {
+			info.GroupList = activityFleetGroupsToProto(groups)
+		}
 		response.ActivityList = append(response.ActivityList, info)
 	}
 	return client.SendMessage(11200, &response)

--- a/internal/answer/activity_fleet.go
+++ b/internal/answer/activity_fleet.go
@@ -1,0 +1,84 @@
+package answer
+
+import (
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func EditActivityFleet(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var payload protobuf.CS_11204
+	if err := proto.Unmarshal(*buffer, &payload); err != nil {
+		return 0, 11205, err
+	}
+
+	response := protobuf.SC_11205{
+		ActivityId: proto.Uint32(payload.GetActivityId()),
+		Result:     proto.Uint32(1),
+	}
+
+	if _, err := loadActivityTemplate(payload.GetActivityId()); err != nil {
+		return client.SendMessage(11205, &response)
+	}
+
+	for _, group := range payload.GetGroupList() {
+		for _, shipID := range group.GetShipList() {
+			if _, ok := client.Commander.OwnedShipsMap[shipID]; !ok {
+				return client.SendMessage(11205, &response)
+			}
+		}
+	}
+
+	groups := activityFleetGroupsFromProto(payload.GetGroupList())
+	if err := orm.SaveActivityFleetGroups(client.Commander.CommanderID, payload.GetActivityId(), groups); err != nil {
+		return client.SendMessage(11205, &response)
+	}
+
+	response.Result = proto.Uint32(0)
+	return client.SendMessage(11205, &response)
+}
+
+func activityFleetGroupsFromProto(groups []*protobuf.GROUPINFO_P11) orm.ActivityFleetGroupList {
+	if len(groups) == 0 {
+		return orm.ActivityFleetGroupList{}
+	}
+	result := make(orm.ActivityFleetGroupList, 0, len(groups))
+	for _, group := range groups {
+		commanders := make([]orm.ActivityFleetCommander, 0, len(group.GetCommanders()))
+		for _, commander := range group.GetCommanders() {
+			commanders = append(commanders, orm.ActivityFleetCommander{
+				Pos: commander.GetPos(),
+				ID:  commander.GetId(),
+			})
+		}
+		result = append(result, orm.ActivityFleetGroup{
+			ID:         group.GetId(),
+			ShipList:   append([]uint32(nil), group.GetShipList()...),
+			Commanders: commanders,
+		})
+	}
+	return result
+}
+
+func activityFleetGroupsToProto(groups orm.ActivityFleetGroupList) []*protobuf.GROUPINFO_P11 {
+	if len(groups) == 0 {
+		return []*protobuf.GROUPINFO_P11{}
+	}
+	result := make([]*protobuf.GROUPINFO_P11, 0, len(groups))
+	for _, group := range groups {
+		commanders := make([]*protobuf.COMMANDERSINFO, 0, len(group.Commanders))
+		for _, commander := range group.Commanders {
+			commanders = append(commanders, &protobuf.COMMANDERSINFO{
+				Pos: proto.Uint32(commander.Pos),
+				Id:  proto.Uint32(commander.ID),
+			})
+		}
+		result = append(result, &protobuf.GROUPINFO_P11{
+			Id:         proto.Uint32(group.ID),
+			ShipList:   append([]uint32(nil), group.ShipList...),
+			Commanders: commanders,
+		})
+	}
+	return result
+}

--- a/internal/answer/activity_fleet_test.go
+++ b/internal/answer/activity_fleet_test.go
@@ -1,0 +1,137 @@
+package answer
+
+import (
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestEditActivityFleetSuccess(t *testing.T) {
+	client := setupConfigTest(t)
+	clearTable(t, &orm.ActivityFleet{})
+	seedConfigEntry(t, "ShareCfg/activity_template.json", "10", `{"id":10}`)
+
+	client.Commander.OwnedShipsMap = map[uint32]*orm.OwnedShip{
+		1: {ID: 1, OwnerID: client.Commander.CommanderID, ShipID: 100},
+	}
+
+	request := protobuf.CS_11204{
+		ActivityId: proto.Uint32(10),
+		GroupList: []*protobuf.GROUPINFO_P11{
+			{
+				Id:       proto.Uint32(1),
+				ShipList: []uint32{1},
+				Commanders: []*protobuf.COMMANDERSINFO{
+					{Pos: proto.Uint32(1), Id: proto.Uint32(99)},
+				},
+			},
+		},
+	}
+	data, err := proto.Marshal(&request)
+	if err != nil {
+		t.Fatalf("marshal request failed: %v", err)
+	}
+
+	buffer := data
+	if _, _, err := EditActivityFleet(&buffer, client); err != nil {
+		t.Fatalf("edit activity fleet failed: %v", err)
+	}
+
+	var response protobuf.SC_11205
+	decodeResponse(t, client, &response)
+	if response.GetResult() != 0 {
+		t.Fatalf("expected result 0, got %d", response.GetResult())
+	}
+	if response.GetActivityId() != 10 {
+		t.Fatalf("expected activity id 10, got %d", response.GetActivityId())
+	}
+
+	groups, found, err := orm.LoadActivityFleetGroups(client.Commander.CommanderID, 10)
+	if err != nil {
+		t.Fatalf("load activity fleet groups failed: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected activity fleet groups to be stored")
+	}
+	if len(groups) != 1 || groups[0].ID != 1 {
+		t.Fatalf("unexpected groups: %v", groups)
+	}
+}
+
+func TestEditActivityFleetInvalidShip(t *testing.T) {
+	client := setupConfigTest(t)
+	clearTable(t, &orm.ActivityFleet{})
+	seedConfigEntry(t, "ShareCfg/activity_template.json", "10", `{"id":10}`)
+
+	client.Commander.OwnedShipsMap = map[uint32]*orm.OwnedShip{}
+
+	request := protobuf.CS_11204{
+		ActivityId: proto.Uint32(10),
+		GroupList: []*protobuf.GROUPINFO_P11{
+			{
+				Id:       proto.Uint32(1),
+				ShipList: []uint32{999},
+			},
+		},
+	}
+	data, err := proto.Marshal(&request)
+	if err != nil {
+		t.Fatalf("marshal request failed: %v", err)
+	}
+
+	buffer := data
+	if _, _, err := EditActivityFleet(&buffer, client); err != nil {
+		t.Fatalf("edit activity fleet failed: %v", err)
+	}
+
+	var response protobuf.SC_11205
+	decodeResponse(t, client, &response)
+	if response.GetResult() != 1 {
+		t.Fatalf("expected result 1, got %d", response.GetResult())
+	}
+
+	_, found, err := orm.LoadActivityFleetGroups(client.Commander.CommanderID, 10)
+	if err != nil {
+		t.Fatalf("load activity fleet groups failed: %v", err)
+	}
+	if found {
+		t.Fatalf("expected activity fleet groups to be absent")
+	}
+}
+
+func TestActivitiesIncludeStoredActivityFleetGroups(t *testing.T) {
+	client := setupConfigTest(t)
+	clearTable(t, &orm.ActivityFleet{})
+	seedConfigEntry(t, "ShareCfg/activity_template.json", "1", `{"id":1,"time":["timer",[[2024,1,1],[0,0,0]],[[2024,1,2],[0,0,0]]]}`)
+	seedActivityAllowlist(t, []uint32{1})
+
+	groups := orm.ActivityFleetGroupList{
+		{
+			ID:       5,
+			ShipList: []uint32{1, 2},
+			Commanders: []orm.ActivityFleetCommander{
+				{Pos: 1, ID: 77},
+			},
+		},
+	}
+	if err := orm.SaveActivityFleetGroups(client.Commander.CommanderID, 1, groups); err != nil {
+		t.Fatalf("save activity fleet groups failed: %v", err)
+	}
+
+	buffer := []byte{}
+	if _, _, err := Activities(&buffer, client); err != nil {
+		t.Fatalf("activities failed: %v", err)
+	}
+
+	var response protobuf.SC_11200
+	decodeResponse(t, client, &response)
+	if len(response.GetActivityList()) != 1 {
+		t.Fatalf("expected 1 activity, got %d", len(response.GetActivityList()))
+	}
+	activity := response.GetActivityList()[0]
+	if len(activity.GetGroupList()) != 1 || activity.GetGroupList()[0].GetId() != 5 {
+		t.Fatalf("expected stored group list to be included")
+	}
+}

--- a/internal/entrypoint/packet_registry.go
+++ b/internal/entrypoint/packet_registry.go
@@ -99,6 +99,7 @@ func registerPackets() {
 	packets.RegisterPacketHandler(13505, []packets.PacketHandler{answer.RemasterInfo})
 	packets.RegisterPacketHandler(13507, []packets.PacketHandler{answer.RemasterAwardReceive})
 	packets.RegisterPacketHandler(11202, []packets.PacketHandler{answer.ActivityOperation})
+	packets.RegisterPacketHandler(11204, []packets.PacketHandler{answer.EditActivityFleet})
 	packets.RegisterPacketHandler(11751, []packets.PacketHandler{answer.LastOnlineInfo})
 	packets.RegisterPacketHandler(11722, []packets.PacketHandler{answer.InstagramChatActivateTopic})
 	packets.RegisterPacketHandler(11005, []packets.PacketHandler{answer.AttireApply})

--- a/internal/orm/activity_fleet.go
+++ b/internal/orm/activity_fleet.go
@@ -1,0 +1,82 @@
+package orm
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+type ActivityFleet struct {
+	CommanderID uint32                 `gorm:"primaryKey"`
+	ActivityID  uint32                 `gorm:"primaryKey"`
+	GroupList   ActivityFleetGroupList `gorm:"type:text;not_null;default:'[]'"`
+}
+
+type ActivityFleetCommander struct {
+	Pos uint32 `json:"pos"`
+	ID  uint32 `json:"id"`
+}
+
+type ActivityFleetGroup struct {
+	ID         uint32                   `json:"id"`
+	ShipList   []uint32                 `json:"ship_list"`
+	Commanders []ActivityFleetCommander `json:"commanders"`
+}
+
+type ActivityFleetGroupList []ActivityFleetGroup
+
+func (list ActivityFleetGroupList) Value() (driver.Value, error) {
+	payload, err := json.Marshal(list)
+	if err != nil {
+		return nil, err
+	}
+	return string(payload), nil
+}
+
+func (list *ActivityFleetGroupList) Scan(value any) error {
+	if value == nil {
+		*list = nil
+		return nil
+	}
+	switch v := value.(type) {
+	case string:
+		return json.Unmarshal([]byte(v), list)
+	case []byte:
+		return json.Unmarshal(v, list)
+	default:
+		return fmt.Errorf("unsupported ActivityFleetGroupList type: %T", value)
+	}
+}
+
+func LoadActivityFleetGroups(commanderID uint32, activityID uint32) (ActivityFleetGroupList, bool, error) {
+	var entry ActivityFleet
+	err := GormDB.Where("commander_id = ? AND activity_id = ?", commanderID, activityID).First(&entry).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return entry.GroupList, true, nil
+}
+
+func SaveActivityFleetGroups(commanderID uint32, activityID uint32, groups ActivityFleetGroupList) error {
+	var entry ActivityFleet
+	err := GormDB.Where("commander_id = ? AND activity_id = ?", commanderID, activityID).First(&entry).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			entry = ActivityFleet{
+				CommanderID: commanderID,
+				ActivityID:  activityID,
+				GroupList:   groups,
+			}
+			return GormDB.Create(&entry).Error
+		}
+		return err
+	}
+	entry.GroupList = groups
+	return GormDB.Save(&entry).Error
+}

--- a/internal/orm/activity_fleet_test.go
+++ b/internal/orm/activity_fleet_test.go
@@ -1,0 +1,48 @@
+package orm
+
+import (
+	"os"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+func TestActivityFleetGroupRoundTrip(t *testing.T) {
+	os.Setenv("MODE", "test")
+	InitDatabase()
+	if err := GormDB.Session(&gorm.Session{AllowGlobalUpdate: true}).Unscoped().Delete(&ActivityFleet{}).Error; err != nil {
+		t.Fatalf("failed to clear activity fleets: %v", err)
+	}
+	groups := ActivityFleetGroupList{
+		{
+			ID:       1,
+			ShipList: []uint32{10, 11},
+			Commanders: []ActivityFleetCommander{
+				{Pos: 1, ID: 99},
+				{Pos: 2, ID: 100},
+			},
+		},
+	}
+	if err := SaveActivityFleetGroups(7, 42, groups); err != nil {
+		t.Fatalf("save activity fleet groups failed: %v", err)
+	}
+	loaded, found, err := LoadActivityFleetGroups(7, 42)
+	if err != nil {
+		t.Fatalf("load activity fleet groups failed: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected activity fleet groups to be found")
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(loaded))
+	}
+	if loaded[0].ID != 1 {
+		t.Fatalf("expected group id 1, got %d", loaded[0].ID)
+	}
+	if len(loaded[0].ShipList) != 2 || loaded[0].ShipList[0] != 10 || loaded[0].ShipList[1] != 11 {
+		t.Fatalf("unexpected ship list: %v", loaded[0].ShipList)
+	}
+	if len(loaded[0].Commanders) != 2 || loaded[0].Commanders[0].ID != 99 || loaded[0].Commanders[1].ID != 100 {
+		t.Fatalf("unexpected commanders: %v", loaded[0].Commanders)
+	}
+}

--- a/internal/orm/database.go
+++ b/internal/orm/database.go
@@ -64,6 +64,7 @@ func seedDatabase(skipSeed bool) bool {
 		&MedalShopGood{},
 		&MiniGameShopState{},
 		&MiniGameShopGood{},
+		&ActivityFleet{},
 		// Debug stuff
 		&DebugName{},
 		&Debug{},


### PR DESCRIPTION
# Summary
- Persist activity fleet group_list per commander and activity
- Return stored activity fleets in activity list responses
- Handle CS_11204 edit requests with validation and result codes

# Changes
- add ActivityFleet ORM model, JSON group storage, and migrations
- implement CS_11204 handler and protobuf conversions
- wire packet registration and activity list hydration
- add tests for persistence, handler results, and activity list output
