### PR TITLE
feat(answer): add emoji info response

### DIFF
--- a/internal/answer/emoji_info_request.go
+++ b/internal/answer/emoji_info_request.go
@@ -1,0 +1,45 @@
+package answer
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+type emojiTemplateEntry struct {
+	ID      uint32 `json:"id"`
+	Achieve uint32 `json:"achieve"`
+}
+
+func EmojiInfoRequest(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var data protobuf.CS_11601
+	if err := proto.Unmarshal(*buffer, &data); err != nil {
+		return 0, 11601, err
+	}
+
+	entries, err := orm.ListConfigEntries(orm.GormDB, "ShareCfg/emoji_template.json")
+	if err != nil {
+		return 0, 11601, err
+	}
+
+	emojiList := make([]uint32, 0)
+	for _, entry := range entries {
+		var template emojiTemplateEntry
+		if err := json.Unmarshal(entry.Data, &template); err != nil {
+			return 0, 11601, err
+		}
+		if template.Achieve == 1 {
+			emojiList = append(emojiList, template.ID)
+		}
+	}
+	sort.Slice(emojiList, func(i, j int) bool {
+		return emojiList[i] < emojiList[j]
+	})
+
+	response := protobuf.SC_11602{EmojiList: emojiList}
+	return client.SendMessage(11602, &response)
+}

--- a/internal/answer/emoji_info_request_test.go
+++ b/internal/answer/emoji_info_request_test.go
@@ -1,0 +1,62 @@
+package answer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestEmojiInfoRequestFiltersAchieve(t *testing.T) {
+	client := setupConfigTest(t)
+	seedConfigEntry(t, "ShareCfg/emoji_template.json", "1", `{"id":1,"achieve":0}`)
+	seedConfigEntry(t, "ShareCfg/emoji_template.json", "3", `{"id":3,"achieve":1}`)
+	seedConfigEntry(t, "ShareCfg/emoji_template.json", "10", `{"id":10,"achieve":1}`)
+
+	payload := protobuf.CS_11601{Type: proto.Uint32(0)}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	if _, _, err := EmojiInfoRequest(&buffer, client); err != nil {
+		t.Fatalf("EmojiInfoRequest failed: %v", err)
+	}
+
+	packetIDs := decodePacketIDs(t, client.Buffer.Bytes())
+	if len(packetIDs) != 1 || packetIDs[0] != 11602 {
+		t.Fatalf("expected packet id 11602, got %v", packetIDs)
+	}
+
+	response := &protobuf.SC_11602{}
+	if err := proto.Unmarshal(decodeFirstPacketPayload(t, client.Buffer.Bytes()), response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if !reflect.DeepEqual(response.EmojiList, []uint32{3, 10}) {
+		t.Fatalf("expected emoji list [3 10], got %v", response.EmojiList)
+	}
+}
+
+func TestEmojiInfoRequestEmptyConfig(t *testing.T) {
+	client := setupConfigTest(t)
+	payload := protobuf.CS_11601{Type: proto.Uint32(0)}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	if _, _, err := EmojiInfoRequest(&buffer, client); err != nil {
+		t.Fatalf("EmojiInfoRequest failed: %v", err)
+	}
+
+	response := &protobuf.SC_11602{}
+	if err := proto.Unmarshal(decodeFirstPacketPayload(t, client.Buffer.Bytes()), response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if len(response.EmojiList) != 0 {
+		t.Fatalf("expected empty emoji list, got %v", response.EmojiList)
+	}
+}

--- a/internal/entrypoint/packet_registry.go
+++ b/internal/entrypoint/packet_registry.go
@@ -86,6 +86,7 @@ func registerPackets() {
 	packets.RegisterPacketHandler(24020, []packets.PacketHandler{answer.LimitChallengeInfo})
 	packets.RegisterPacketHandler(24004, []packets.PacketHandler{answer.ChallengeInfo})
 	packets.RegisterPacketHandler(26051, []packets.PacketHandler{answer.AtelierRequest})
+	packets.RegisterPacketHandler(11601, []packets.PacketHandler{answer.EmojiInfoRequest})
 	packets.RegisterPacketHandler(11603, []packets.PacketHandler{answer.FetchSecondaryPasswordCommandResponse})
 	packets.RegisterPacketHandler(17203, []packets.PacketHandler{answer.FetchVoteInfo})
 	packets.RegisterPacketHandler(16104, []packets.PacketHandler{answer.GetChargeList})

--- a/internal/misc/update_data.go
+++ b/internal/misc/update_data.go
@@ -149,6 +149,7 @@ func importConfigEntries(region string, tx *gorm.DB) error {
 			"ShareCfg/re_map_template.json",
 			"ShareCfg/shop_banner_template.json",
 			"ShareCfg/shop_discount_coupon_template.json",
+			"ShareCfg/emoji_template.json",
 			"sharecfgdata/expedition_data_template.json",
 			"ShareCfg/ship_level.json",
 			"ShareCfg/user_level.json",


### PR DESCRIPTION
# Summary
- Add emoji info response handling for the answer pipeline.
- Register the new emoji info packet and keep data update wiring in sync.
- Add tests covering emoji info requests.

# Changes
- Create emoji info request handler and corresponding tests.
- Wire the handler into packet registry updates.
