### PR TITLE
feat(packets): respond with ship count

### DIFF
--- a/internal/answer/get_ship_count.go
+++ b/internal/answer/get_ship_count.go
@@ -1,0 +1,20 @@
+package answer
+
+import (
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func GetShipCount(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var payload protobuf.CS_11800
+	if err := proto.Unmarshal(*buffer, &payload); err != nil {
+		return 0, 11801, err
+	}
+
+	response := protobuf.SC_11801{
+		ShipCount: proto.Uint32(uint32(len(client.Commander.Ships))),
+	}
+
+	return client.SendMessage(11801, &response)
+}

--- a/internal/answer/get_ship_count_test.go
+++ b/internal/answer/get_ship_count_test.go
@@ -1,0 +1,74 @@
+package answer
+
+import (
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestGetShipCountEmpty(t *testing.T) {
+	commander := &orm.Commander{Ships: []orm.OwnedShip{}}
+	client := &connection.Client{Commander: commander}
+	payload := protobuf.CS_11800{Type: proto.Uint32(0)}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	_, packetID, err := GetShipCount(&buffer, client)
+	if err != nil {
+		t.Fatalf("get ship count failed: %v", err)
+	}
+	if packetID != 11801 {
+		t.Fatalf("expected packet 11801, got %d", packetID)
+	}
+
+	data := client.Buffer.Bytes()
+	if len(data) < 7 {
+		t.Fatalf("expected buffer to include header and payload")
+	}
+	data = data[7:]
+
+	var response protobuf.SC_11801
+	if err := proto.Unmarshal(data, &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if response.GetShipCount() != 0 {
+		t.Fatalf("expected ship_count 0, got %d", response.GetShipCount())
+	}
+}
+
+func TestGetShipCountWithShips(t *testing.T) {
+	commander := &orm.Commander{Ships: []orm.OwnedShip{{ID: 1}, {ID: 2}, {ID: 3}}}
+	client := &connection.Client{Commander: commander}
+	payload := protobuf.CS_11800{Type: proto.Uint32(0)}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	_, packetID, err := GetShipCount(&buffer, client)
+	if err != nil {
+		t.Fatalf("get ship count failed: %v", err)
+	}
+	if packetID != 11801 {
+		t.Fatalf("expected packet 11801, got %d", packetID)
+	}
+
+	data := client.Buffer.Bytes()
+	if len(data) < 7 {
+		t.Fatalf("expected buffer to include header and payload")
+	}
+	data = data[7:]
+
+	var response protobuf.SC_11801
+	if err := proto.Unmarshal(data, &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if response.GetShipCount() != 3 {
+		t.Fatalf("expected ship_count 3, got %d", response.GetShipCount())
+	}
+}

--- a/internal/entrypoint/packet_registry.go
+++ b/internal/entrypoint/packet_registry.go
@@ -184,6 +184,7 @@ func registerPackets() {
 	packets.RegisterPacketHandler(11716, []packets.PacketHandler{answer.InstagramChatSetCare})
 	packets.RegisterPacketHandler(11718, []packets.PacketHandler{answer.InstagramChatSetTopic})
 	packets.RegisterPacketHandler(11720, []packets.PacketHandler{answer.JuustagramReadTip})
+	packets.RegisterPacketHandler(11800, []packets.PacketHandler{answer.GetShipCount})
 	packets.RegisterPacketHandler(10991, []packets.PacketHandler{answer.GameTracking})
 	packets.RegisterPacketHandler(10992, []packets.PacketHandler{answer.NewTracking})
 	packets.RegisterPacketHandler(10993, []packets.PacketHandler{answer.TrackCommand})


### PR DESCRIPTION
# Summary
- Responds to the client ship-count request with the commander’s current owned-ship total.
- Ensures the ship-count integrity check in the client flow receives a consistent value.

# Changes
- add CS_11800 handler returning SC_11801 with current ship count
- register the new packet handler in the packet registry
- add handler tests for empty and non-empty ship lists
