### PR TITLE
feat(ships): add ship action ack handler

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,9 @@
+# Non-implemented CS packets (p12_pb.lua)
+
+- CS_12027
+- CS_12029
+- CS_12036
+- CS_12038
+- CS_12210
+- CS_12212
+- CS_12301

--- a/internal/answer/ship_action_12020.go
+++ b/internal/answer/ship_action_12020.go
@@ -1,0 +1,21 @@
+package answer
+
+import (
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func ShipAction12020(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var data protobuf.CS_12020
+	if err := proto.Unmarshal(*buffer, &data); err != nil {
+		return 0, 12021, err
+	}
+
+	response := protobuf.SC_12021{Result: proto.Uint32(1)}
+	if _, ok := client.Commander.OwnedShipsMap[data.GetShipId()]; ok {
+		response.Result = proto.Uint32(0)
+	}
+
+	return client.SendMessage(12021, &response)
+}

--- a/internal/answer/ship_action_12020_test.go
+++ b/internal/answer/ship_action_12020_test.go
@@ -1,0 +1,92 @@
+package answer
+
+import (
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestShipAction12020Success(t *testing.T) {
+	commander := &orm.Commander{
+		OwnedShipsMap: map[uint32]*orm.OwnedShip{
+			10: {ID: 10},
+		},
+	}
+	client := &connection.Client{Commander: commander}
+	payload := protobuf.CS_12020{ShipId: proto.Uint32(10)}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	_, packetID, err := ShipAction12020(&buffer, client)
+	if err != nil {
+		t.Fatalf("ship action failed: %v", err)
+	}
+	if packetID != 12021 {
+		t.Fatalf("expected packet 12021, got %d", packetID)
+	}
+
+	data := client.Buffer.Bytes()
+	if len(data) < 7 {
+		t.Fatalf("expected buffer to include header and payload")
+	}
+	data = data[7:]
+
+	var response protobuf.SC_12021
+	if err := proto.Unmarshal(data, &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if response.GetResult() != 0 {
+		t.Fatalf("expected result 0, got %d", response.GetResult())
+	}
+}
+
+func TestShipAction12020MissingShip(t *testing.T) {
+	commander := &orm.Commander{OwnedShipsMap: map[uint32]*orm.OwnedShip{}}
+	client := &connection.Client{Commander: commander}
+	payload := protobuf.CS_12020{ShipId: proto.Uint32(99)}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	_, packetID, err := ShipAction12020(&buffer, client)
+	if err != nil {
+		t.Fatalf("ship action failed: %v", err)
+	}
+	if packetID != 12021 {
+		t.Fatalf("expected packet 12021, got %d", packetID)
+	}
+
+	data := client.Buffer.Bytes()
+	if len(data) < 7 {
+		t.Fatalf("expected buffer to include header and payload")
+	}
+	data = data[7:]
+
+	var response protobuf.SC_12021
+	if err := proto.Unmarshal(data, &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if response.GetResult() != 1 {
+		t.Fatalf("expected result 1, got %d", response.GetResult())
+	}
+}
+
+func TestShipAction12020BadPayload(t *testing.T) {
+	commander := &orm.Commander{OwnedShipsMap: map[uint32]*orm.OwnedShip{}}
+	client := &connection.Client{Commander: commander}
+	buffer := []byte{0xff}
+
+	_, packetID, err := ShipAction12020(&buffer, client)
+	if err == nil {
+		t.Fatalf("expected unmarshal error")
+	}
+	if packetID != 12021 {
+		t.Fatalf("expected packet 12021, got %d", packetID)
+	}
+}

--- a/internal/entrypoint/packet_registry.go
+++ b/internal/entrypoint/packet_registry.go
@@ -163,6 +163,7 @@ func registerPackets() {
 	packets.RegisterPacketHandler(12008, []packets.PacketHandler{answer.BuildQuickFinish})
 	packets.RegisterPacketHandler(12011, []packets.PacketHandler{answer.RemouldShip})
 	packets.RegisterPacketHandler(12043, []packets.PacketHandler{answer.BuildFinish})
+	packets.RegisterPacketHandler(12020, []packets.PacketHandler{answer.ShipAction12020})
 	packets.RegisterPacketHandler(12025, []packets.PacketHandler{answer.GetShip})
 	packets.RegisterPacketHandler(12045, []packets.PacketHandler{answer.ConfirmShip})
 	packets.RegisterPacketHandler(12006, []packets.PacketHandler{answer.EquipToShip})


### PR DESCRIPTION
# Summary
- Add a handler that acknowledges the ship action request with success or failure based on ownership.
- Register the new handler in packet routing.
- Include tests covering success, missing ship, and bad payload cases.

# Changes
- Add `ShipAction12020` handler and tests for CS_12020/SC_12021 behavior.
- Register packet 12020 in `internal/entrypoint/packet_registry.go`.
- Update `TODO.md` to remove the implemented packet.
