### PR TITLE
feat(ships): add ship action handler

### DIFF
--- a/internal/answer/ship_action_12029.go
+++ b/internal/answer/ship_action_12029.go
@@ -1,0 +1,21 @@
+package answer
+
+import (
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func ShipAction12029(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var data protobuf.CS_12029
+	if err := proto.Unmarshal(*buffer, &data); err != nil {
+		return 0, 12030, err
+	}
+
+	response := protobuf.SC_12030{
+		Result:   proto.Uint32(0),
+		ShipList: []*protobuf.SHIPINFO{},
+	}
+
+	return client.SendMessage(12030, &response)
+}

--- a/internal/answer/ship_action_12029_test.go
+++ b/internal/answer/ship_action_12029_test.go
@@ -1,0 +1,66 @@
+package answer
+
+import (
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestShipAction12029Success(t *testing.T) {
+	commander := &orm.Commander{
+		OwnedShipsMap: map[uint32]*orm.OwnedShip{
+			10: {ID: 10},
+		},
+	}
+	client := &connection.Client{Commander: commander}
+	payload := protobuf.CS_12029{Id: proto.Uint32(1), Num: proto.Uint32(2)}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	_, packetID, err := ShipAction12029(&buffer, client)
+	if err != nil {
+		t.Fatalf("ship action failed: %v", err)
+	}
+	if packetID != 12030 {
+		t.Fatalf("expected packet 12030, got %d", packetID)
+	}
+	if len(commander.OwnedShipsMap) != 1 {
+		t.Fatalf("expected owned ships unchanged, got %d", len(commander.OwnedShipsMap))
+	}
+
+	data := client.Buffer.Bytes()
+	if len(data) < 7 {
+		t.Fatalf("expected buffer to include header and payload")
+	}
+	data = data[7:]
+
+	var response protobuf.SC_12030
+	if err := proto.Unmarshal(data, &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if response.GetResult() != 0 {
+		t.Fatalf("expected result 0, got %d", response.GetResult())
+	}
+	if len(response.GetShipList()) != 0 {
+		t.Fatalf("expected empty ship list, got %d", len(response.GetShipList()))
+	}
+}
+
+func TestShipAction12029BadPayload(t *testing.T) {
+	commander := &orm.Commander{OwnedShipsMap: map[uint32]*orm.OwnedShip{}}
+	client := &connection.Client{Commander: commander}
+	buffer := []byte{0xff}
+
+	_, packetID, err := ShipAction12029(&buffer, client)
+	if err == nil {
+		t.Fatalf("expected unmarshal error")
+	}
+	if packetID != 12030 {
+		t.Fatalf("expected packet 12030, got %d", packetID)
+	}
+}

--- a/internal/entrypoint/packet_registry.go
+++ b/internal/entrypoint/packet_registry.go
@@ -166,6 +166,7 @@ func registerPackets() {
 	packets.RegisterPacketHandler(12020, []packets.PacketHandler{answer.ShipAction12020})
 	packets.RegisterPacketHandler(12025, []packets.PacketHandler{answer.GetShip})
 	packets.RegisterPacketHandler(12027, []packets.PacketHandler{answer.UpgradeStar})
+	packets.RegisterPacketHandler(12029, []packets.PacketHandler{answer.ShipAction12029})
 	packets.RegisterPacketHandler(12045, []packets.PacketHandler{answer.ConfirmShip})
 	packets.RegisterPacketHandler(12006, []packets.PacketHandler{answer.EquipToShip})
 	packets.RegisterPacketHandler(16100, []packets.PacketHandler{answer.SupportShipRequisition})


### PR DESCRIPTION
# Summary
- handle the ship action request by returning a success response
- register the new packet handler so the server accepts the request

# Changes
- add a handler for the ship action request and response
- add tests for success and bad payload cases
- wire the handler into packet registry
