### PR TITLE
feat: handle equip code share list request

### DIFF
--- a/internal/answer/equip_code_share_list_request.go
+++ b/internal/answer/equip_code_share_list_request.go
@@ -1,0 +1,25 @@
+package answer
+
+import (
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func EquipCodeShareListRequest(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var data protobuf.CS_17601
+	err := proto.Unmarshal(*buffer, &data)
+	if err != nil {
+		return 0, 17601, err
+	}
+
+	// Phase 1: unblock the UI by replying successfully with empty lists.
+	_ = data.GetShipgroup()
+	response := protobuf.SC_17602{
+		Result:      proto.Uint32(0),
+		Infos:       []*protobuf.EQCODE_SHARE_INFO{},
+		RecentInfos: []*protobuf.EQCODE_SHARE_INFO{},
+	}
+
+	return client.SendMessage(17602, &response)
+}

--- a/internal/answer/equip_code_share_list_request_test.go
+++ b/internal/answer/equip_code_share_list_request_test.go
@@ -1,0 +1,38 @@
+package answer_test
+
+import (
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/answer"
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestEquipCodeShareListRequestReturnsEmptyLists(t *testing.T) {
+	client := &connection.Client{}
+	payload := &protobuf.CS_17601{Shipgroup: proto.Uint32(1001)}
+	buf, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+
+	if _, _, err := answer.EquipCodeShareListRequest(&buf, client); err != nil {
+		t.Fatalf("EquipCodeShareListRequest failed: %v", err)
+	}
+
+	response := &protobuf.SC_17602{}
+	packetId := decodeTestPacket(t, client, 17602, response)
+	if packetId != 17602 {
+		t.Fatalf("expected packet 17602, got %d", packetId)
+	}
+	if response.GetResult() != 0 {
+		t.Fatalf("expected result 0, got %d", response.GetResult())
+	}
+	if len(response.GetInfos()) != 0 {
+		t.Fatalf("expected infos to be empty, got %d", len(response.GetInfos()))
+	}
+	if len(response.GetRecentInfos()) != 0 {
+		t.Fatalf("expected recent_infos to be empty, got %d", len(response.GetRecentInfos()))
+	}
+}

--- a/internal/entrypoint/packet_registry.go
+++ b/internal/entrypoint/packet_registry.go
@@ -275,6 +275,7 @@ func registerPackets() {
 	packets.RegisterPacketHandler(17101, []packets.PacketHandler{answer.GetShipDiscuss})
 	packets.RegisterPacketHandler(17103, []packets.PacketHandler{answer.PostShipEvaluationComment})
 	packets.RegisterPacketHandler(17107, []packets.PacketHandler{answer.UpdateShipLike})
+	packets.RegisterPacketHandler(17601, []packets.PacketHandler{answer.EquipCodeShareListRequest})
 	packets.RegisterPacketHandler(17607, []packets.PacketHandler{answer.EquipCodeImpeach})
 	packets.RegisterPacketHandler(17503, []packets.PacketHandler{answer.UnlockAppreciateMusic})
 	packets.RegisterPacketHandler(17509, []packets.PacketHandler{answer.MarkMangaRead})


### PR DESCRIPTION
# Summary
- Handle equip code share list requests by returning a successful response with empty lists.
- Wire the handler into the packet registry so the client no longer hits a missing-handler path.

# Changes
- Add `CS_17601` -> `SC_17602` handler with phase-1 behavior (empty `infos` / `recent_infos`).
- Register packet id `17601` to route to the new handler.
- Add a unit test that exercises the handler and decodes `SC_17602`.
