### PR TITLE
feat: handle escort info query

### DIFF
--- a/internal/answer/escort_query.go
+++ b/internal/answer/escort_query.go
@@ -1,0 +1,43 @@
+package answer
+
+import (
+	"fmt"
+
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/logger"
+	"github.com/ggmolly/belfast/internal/misc"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func EscortQuery(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var payload protobuf.CS_13301
+	if err := proto.Unmarshal(*buffer, &payload); err != nil {
+		return 0, 13302, err
+	}
+
+	if payload.GetType() != 0 && payload.GetType() != 1 {
+		logger.LogEvent("Escort", "Query", fmt.Sprintf("unknown query type %d", payload.GetType()), logger.LOG_LEVEL_INFO)
+	}
+
+	// Escort config is expected to come from belfast-data imports. If config isn't
+	// available yet, fall back to returning persisted state only.
+	if _, err := misc.GetEscortConfig(); err != nil {
+		logger.LogEvent("Escort", "Config", fmt.Sprintf("failed to load escort config: %v", err), logger.LOG_LEVEL_ERROR)
+	}
+
+	escortInfo := []*protobuf.ESCORT_INFO{}
+	if client.Commander != nil {
+		infos, err := misc.LoadEscortState(client.Commander.AccountID)
+		if err != nil {
+			return 0, 13302, err
+		}
+		escortInfo = infos
+	}
+
+	response := protobuf.SC_13302{
+		EscortInfo: escortInfo,
+		DropList:   []*protobuf.DROPINFO{},
+	}
+	return client.SendMessage(13302, &response)
+}

--- a/internal/answer/escort_query_test.go
+++ b/internal/answer/escort_query_test.go
@@ -1,0 +1,188 @@
+package answer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/misc"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/packets"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func seedConfigEntryEscort(t *testing.T, category string, key string, payload string) {
+	t.Helper()
+	entry := orm.ConfigEntry{Category: category, Key: key, Data: json.RawMessage(payload)}
+	if err := orm.GormDB.Create(&entry).Error; err != nil {
+		t.Fatalf("seed config entry failed: %v", err)
+	}
+}
+
+func decodeSC13302(t *testing.T, clientBuffer []byte) *protobuf.SC_13302 {
+	t.Helper()
+	if len(clientBuffer) == 0 {
+		t.Fatalf("expected response buffer")
+	}
+	packetID := packets.GetPacketId(0, &clientBuffer)
+	if packetID != 13302 {
+		t.Fatalf("expected packet 13302, got %d", packetID)
+	}
+	packetSize := packets.GetPacketSize(0, &clientBuffer) + 2
+	if len(clientBuffer) < packetSize {
+		t.Fatalf("expected packet size %d, got %d", packetSize, len(clientBuffer))
+	}
+	payloadStart := packets.HEADER_SIZE
+	payloadEnd := payloadStart + (packetSize - packets.HEADER_SIZE)
+	var response protobuf.SC_13302
+	if err := proto.Unmarshal(clientBuffer[payloadStart:payloadEnd], &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	return &response
+}
+
+func TestEscortQuery_Type0_ReturnsAllActiveEscorts(t *testing.T) {
+	client := setupHandlerCommander(t)
+	clearTable(t, &orm.EscortState{})
+
+	state1 := orm.EscortState{
+		AccountID:      client.Commander.AccountID,
+		LineID:         20001,
+		AwardTimestamp: 11,
+		FlashTimestamp: 22,
+		MapPositions:   json.RawMessage(`[{"map_id":70000,"chapter_id":101}]`),
+	}
+	state2 := orm.EscortState{
+		AccountID:      client.Commander.AccountID,
+		LineID:         20002,
+		AwardTimestamp: 33,
+		FlashTimestamp: 44,
+		MapPositions:   json.RawMessage(`[{"map_id":70001,"chapter_id":202},{"map_id":70002,"chapter_id":203}]`),
+	}
+	if err := orm.GormDB.Create(&state1).Error; err != nil {
+		t.Fatalf("create escort state: %v", err)
+	}
+	if err := orm.GormDB.Create(&state2).Error; err != nil {
+		t.Fatalf("create escort state: %v", err)
+	}
+
+	payload := protobuf.CS_13301{Type: proto.Uint32(0)}
+	data, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	client.Buffer.Reset()
+	if _, _, err := EscortQuery(&data, client); err != nil {
+		t.Fatalf("EscortQuery failed: %v", err)
+	}
+
+	response := decodeSC13302(t, client.Buffer.Bytes())
+	if len(response.GetEscortInfo()) != 2 {
+		t.Fatalf("expected 2 escort entries, got %d", len(response.GetEscortInfo()))
+	}
+	if response.GetEscortInfo()[0].GetLineId() != 20001 {
+		t.Fatalf("expected line_id 20001, got %d", response.GetEscortInfo()[0].GetLineId())
+	}
+	if response.GetEscortInfo()[0].GetAwardTimestamp() != 11 {
+		t.Fatalf("expected award_timestamp 11, got %d", response.GetEscortInfo()[0].GetAwardTimestamp())
+	}
+	if response.GetEscortInfo()[0].GetFlashTimestamp() != 22 {
+		t.Fatalf("expected flash_timestamp 22, got %d", response.GetEscortInfo()[0].GetFlashTimestamp())
+	}
+	if len(response.GetEscortInfo()[0].GetMap()) != 1 {
+		t.Fatalf("expected 1 map entry, got %d", len(response.GetEscortInfo()[0].GetMap()))
+	}
+	if response.GetEscortInfo()[0].GetMap()[0].GetMapId() != 70000 {
+		t.Fatalf("expected map_id 70000, got %d", response.GetEscortInfo()[0].GetMap()[0].GetMapId())
+	}
+	if response.GetEscortInfo()[0].GetMap()[0].GetChapterId() != 101 {
+		t.Fatalf("expected chapter_id 101, got %d", response.GetEscortInfo()[0].GetMap()[0].GetChapterId())
+	}
+
+	if response.GetEscortInfo()[1].GetLineId() != 20002 {
+		t.Fatalf("expected line_id 20002, got %d", response.GetEscortInfo()[1].GetLineId())
+	}
+	if len(response.GetEscortInfo()[1].GetMap()) != 2 {
+		t.Fatalf("expected 2 map entries, got %d", len(response.GetEscortInfo()[1].GetMap()))
+	}
+}
+
+func TestEscortQuery_NoState_ReturnsEmptyList(t *testing.T) {
+	client := setupHandlerCommander(t)
+	clearTable(t, &orm.EscortState{})
+
+	payload := protobuf.CS_13301{Type: proto.Uint32(0)}
+	data, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	client.Buffer.Reset()
+	if _, _, err := EscortQuery(&data, client); err != nil {
+		t.Fatalf("EscortQuery failed: %v", err)
+	}
+
+	response := decodeSC13302(t, client.Buffer.Bytes())
+	if len(response.GetEscortInfo()) != 0 {
+		t.Fatalf("expected empty escort_info, got %d", len(response.GetEscortInfo()))
+	}
+	if len(response.GetDropList()) != 0 {
+		t.Fatalf("expected empty drop_list, got %d", len(response.GetDropList()))
+	}
+}
+
+func TestEscortConfigLoad_LoadsFromConfigEntries(t *testing.T) {
+	_ = setupHandlerCommander(t)
+	clearTable(t, &orm.ConfigEntry{})
+
+	seedConfigEntryEscort(t, "ShareCfg/escort_template.json", "20001", `{"id":20001,"gardroad_reward":[]}`)
+	seedConfigEntryEscort(t, "ShareCfg/escort_map_template.json", "70000", `{"id":70000,"refresh_time":21600,"drop_by_warn":[1,1,1,1,1],"escort_id_list":[1,2,3]}`)
+
+	config, err := misc.GetEscortConfig()
+	if err != nil {
+		t.Fatalf("GetEscortConfig failed: %v", err)
+	}
+	if len(config.Templates) != 1 {
+		t.Fatalf("expected 1 escort template, got %d", len(config.Templates))
+	}
+	if _, ok := config.Templates[20001]; !ok {
+		t.Fatalf("expected escort template id 20001")
+	}
+	if len(config.Maps) != 1 {
+		t.Fatalf("expected 1 escort map template, got %d", len(config.Maps))
+	}
+	if config.Maps[0].RefreshTime != 21600 {
+		t.Fatalf("expected refresh_time 21600, got %d", config.Maps[0].RefreshTime)
+	}
+}
+
+func TestEscortStatePersistence_SaveAndLoad(t *testing.T) {
+	client := setupHandlerCommander(t)
+	clearTable(t, &orm.EscortState{})
+
+	state := orm.EscortState{
+		AccountID:      client.Commander.AccountID,
+		LineID:         20001,
+		AwardTimestamp: 123,
+		FlashTimestamp: 456,
+		MapPositions:   json.RawMessage(`[{"map_id":70000,"chapter_id":101}]`),
+	}
+	if err := orm.GormDB.Create(&state).Error; err != nil {
+		t.Fatalf("create escort state: %v", err)
+	}
+	infos, err := misc.LoadEscortState(client.Commander.AccountID)
+	if err != nil {
+		t.Fatalf("LoadEscortState failed: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 escort info, got %d", len(infos))
+	}
+	if infos[0].GetLineId() != 20001 {
+		t.Fatalf("expected line_id 20001, got %d", infos[0].GetLineId())
+	}
+	if infos[0].GetAwardTimestamp() != 123 {
+		t.Fatalf("expected award_timestamp 123, got %d", infos[0].GetAwardTimestamp())
+	}
+	if infos[0].GetFlashTimestamp() != 456 {
+		t.Fatalf("expected flash_timestamp 456, got %d", infos[0].GetFlashTimestamp())
+	}
+}

--- a/internal/answer/handlers_zero_coverage_test.go
+++ b/internal/answer/handlers_zero_coverage_test.go
@@ -37,6 +37,7 @@ func setupHandlerCommander(t *testing.T) *connection.Client {
 	clearTable(t, &orm.CommanderAppreciationState{})
 	clearTable(t, &orm.SecondaryPasswordState{})
 	clearTable(t, &orm.ActivityPermanentState{})
+	clearTable(t, &orm.EscortState{})
 	commanderID := uint32(time.Now().UnixNano())
 	commander := orm.Commander{
 		CommanderID: commanderID,

--- a/internal/entrypoint/packet_registry.go
+++ b/internal/entrypoint/packet_registry.go
@@ -104,6 +104,7 @@ func registerPackets() {
 	packets.RegisterPacketHandler(13503, []packets.PacketHandler{answer.RemasterTickets})
 	packets.RegisterPacketHandler(13505, []packets.PacketHandler{answer.RemasterInfo})
 	packets.RegisterPacketHandler(13507, []packets.PacketHandler{answer.RemasterAwardReceive})
+	packets.RegisterPacketHandler(13301, []packets.PacketHandler{answer.EscortQuery})
 	packets.RegisterPacketHandler(13403, []packets.PacketHandler{answer.SubmarineChapterInfo})
 	packets.RegisterPacketHandler(11202, []packets.PacketHandler{answer.ActivityOperation})
 	packets.RegisterPacketHandler(11204, []packets.PacketHandler{answer.EditActivityFleet})

--- a/internal/misc/escort.go
+++ b/internal/misc/escort.go
@@ -1,0 +1,124 @@
+package misc
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+	"gorm.io/gorm"
+)
+
+const (
+	escortTemplateCategory    = "ShareCfg/escort_template.json"
+	escortMapTemplateCategory = "ShareCfg/escort_map_template.json"
+)
+
+type EscortTemplate struct {
+	ID             uint32          `json:"id"`
+	GardroadReward json.RawMessage `json:"gardroad_reward"`
+}
+
+type EscortMapTemplate struct {
+	ID           uint32          `json:"id"`
+	RefreshTime  uint32          `json:"refresh_time"`
+	DropByWarn   []uint32        `json:"drop_by_warn"`
+	EscortIDList json.RawMessage `json:"escort_id_list"`
+}
+
+type EscortConfig struct {
+	Templates map[uint32]EscortTemplate
+	Maps      []EscortMapTemplate
+}
+
+func GetEscortConfig() (*EscortConfig, error) {
+	templatesRaw, err := orm.ListConfigEntries(orm.GormDB, escortTemplateCategory)
+	if err != nil {
+		return nil, err
+	}
+	mapsRaw, err := orm.ListConfigEntries(orm.GormDB, escortMapTemplateCategory)
+	if err != nil {
+		return nil, err
+	}
+
+	templates := make(map[uint32]EscortTemplate, len(templatesRaw))
+	for _, entry := range templatesRaw {
+		var template EscortTemplate
+		if err := json.Unmarshal(entry.Data, &template); err != nil {
+			return nil, err
+		}
+		templates[template.ID] = template
+	}
+
+	maps := make([]EscortMapTemplate, 0, len(mapsRaw))
+	for _, entry := range mapsRaw {
+		var template EscortMapTemplate
+		if err := json.Unmarshal(entry.Data, &template); err != nil {
+			return nil, err
+		}
+		maps = append(maps, template)
+	}
+
+	return &EscortConfig{
+		Templates: templates,
+		Maps:      maps,
+	}, nil
+}
+
+type escortPosState struct {
+	MapID     uint32 `json:"map_id"`
+	ChapterID uint32 `json:"chapter_id"`
+}
+
+func LoadEscortState(accountID uint32) ([]*protobuf.ESCORT_INFO, error) {
+	var states []orm.EscortState
+	if err := orm.GormDB.Where("account_id = ?", accountID).Order("line_id asc").Find(&states).Error; err != nil {
+		return nil, err
+	}
+	infos := make([]*protobuf.ESCORT_INFO, 0, len(states))
+	for _, state := range states {
+		positions := []*protobuf.ESCORT_POS{}
+		if len(state.MapPositions) != 0 {
+			var raw []escortPosState
+			if err := json.Unmarshal(state.MapPositions, &raw); err != nil {
+				return nil, err
+			}
+			positions = make([]*protobuf.ESCORT_POS, 0, len(raw))
+			for _, pos := range raw {
+				positions = append(positions, &protobuf.ESCORT_POS{
+					MapId:     proto.Uint32(pos.MapID),
+					ChapterId: proto.Uint32(pos.ChapterID),
+				})
+			}
+		}
+		infos = append(infos, &protobuf.ESCORT_INFO{
+			LineId:         proto.Uint32(state.LineID),
+			AwardTimestamp: proto.Uint32(state.AwardTimestamp),
+			FlashTimestamp: proto.Uint32(state.FlashTimestamp),
+			Map:            positions,
+		})
+	}
+	return infos, nil
+}
+
+func UpdateEscortTimestamps(accountID uint32, lineID uint32, awardTS uint32, flashTS uint32) error {
+	var state orm.EscortState
+	err := orm.GormDB.Where("account_id = ? AND line_id = ?", accountID, lineID).First(&state).Error
+	if err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		state = orm.EscortState{
+			AccountID:    accountID,
+			LineID:       lineID,
+			MapPositions: json.RawMessage("[]"),
+		}
+		state.AwardTimestamp = awardTS
+		state.FlashTimestamp = flashTS
+		return orm.GormDB.Create(&state).Error
+	}
+	state.AwardTimestamp = awardTS
+	state.FlashTimestamp = flashTS
+	return orm.GormDB.Save(&state).Error
+}

--- a/internal/misc/update_data.go
+++ b/internal/misc/update_data.go
@@ -150,6 +150,7 @@ func importConfigEntries(region string, tx *gorm.DB) error {
 			"ShareCfg/quota_shop_template.json",
 			"ShareCfg/recommend_shop.json",
 			"ShareCfg/re_map_template.json",
+			"ShareCfg/escort_template.json",
 			"ShareCfg/escort_map_template.json",
 			"ShareCfg/shop_banner_template.json",
 			"ShareCfg/shop_discount_coupon_template.json",

--- a/internal/orm/database.go
+++ b/internal/orm/database.go
@@ -123,6 +123,7 @@ func seedDatabase(skipSeed bool) bool {
 		&ChapterState{},
 		&ChapterProgress{},
 		&ChapterDrop{},
+		&EscortState{},
 		&BattleSession{},
 		// Skin restrictions
 		&GlobalSkinRestriction{},

--- a/internal/orm/escort_state.go
+++ b/internal/orm/escort_state.go
@@ -1,0 +1,17 @@
+package orm
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type EscortState struct {
+	ID             uint64          `gorm:"primary_key"`
+	AccountID      uint32          `gorm:"not_null;index:idx_escort_account_line,unique"`
+	LineID         uint32          `gorm:"not_null;index:idx_escort_account_line,unique"`
+	AwardTimestamp uint32          `gorm:"not_null;default:0"`
+	FlashTimestamp uint32          `gorm:"not_null;default:0"`
+	MapPositions   json.RawMessage `gorm:"type:json"`
+	CreatedAt      time.Time       `gorm:"type:timestamp;default:CURRENT_TIMESTAMP;not_null"`
+	UpdatedAt      time.Time       `gorm:"type:timestamp;default:CURRENT_TIMESTAMP;not_null"`
+}


### PR DESCRIPTION
# Summary
- Handle escort info query and reply with escort info + drop list.
- Persist escort state per account (timestamps + map positions).
- Load escort config entries imported from belfast-data.

# Changes
- Add CS_13301 handler and wire it into packet registry.
- Add `EscortState` gorm model and migrate via auto-migrate.
- Add misc helpers for escort config and state serialization.
- Add tests for handler response + persistence.
