### PR TITLE
feat: support equipment upgrade transforms

### DIFF
--- a/internal/answer/transform_equipment_14013.go
+++ b/internal/answer/transform_equipment_14013.go
@@ -1,0 +1,161 @@
+package answer
+
+import (
+	"errors"
+
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+	"gorm.io/gorm"
+)
+
+func TransformEquipmentOnShip14013(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var data protobuf.CS_14013
+	if err := proto.Unmarshal(*buffer, &data); err != nil {
+		return 0, 14013, err
+	}
+
+	response := protobuf.SC_14014{Result: proto.Uint32(0)}
+	ship, ok := client.Commander.OwnedShipsMap[data.GetShipId()]
+	if !ok {
+		response.Result = proto.Uint32(1)
+		return client.SendMessage(14014, &response)
+	}
+	config, err := orm.GetShipEquipConfig(ship.ShipID)
+	if err != nil {
+		return 0, 14013, err
+	}
+	pos := data.GetPos()
+	slotCount := config.SlotCount()
+	slotTypes := config.SlotTypes(pos)
+	if pos == 0 || pos > slotCount || len(slotTypes) == 0 {
+		response.Result = proto.Uint32(1)
+		return client.SendMessage(14014, &response)
+	}
+
+	entries, err := orm.ListOwnedShipEquipment(orm.GormDB, client.Commander.CommanderID, ship.ID)
+	if err != nil {
+		return 0, 14013, err
+	}
+	current := findShipEquipment(entries, pos)
+	if current == nil {
+		current = &orm.OwnedShipEquipment{
+			OwnerID: client.Commander.CommanderID,
+			ShipID:  ship.ID,
+			Pos:     pos,
+			EquipID: 0,
+			SkinID:  0,
+		}
+	}
+	if current.EquipID == 0 {
+		response.Result = proto.Uint32(1)
+		return client.SendMessage(14014, &response)
+	}
+
+	upgrade, err := orm.GetEquipUpgradeDataTx(orm.GormDB, data.GetUpgradeId())
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			response.Result = proto.Uint32(1)
+			return client.SendMessage(14014, &response)
+		}
+		return 0, 14013, err
+	}
+	if upgrade.UpgradeFrom != current.EquipID {
+		response.Result = proto.Uint32(1)
+		return client.SendMessage(14014, &response)
+	}
+	targetEquipID := upgrade.TargetID
+	if targetEquipID == 0 {
+		response.Result = proto.Uint32(1)
+		return client.SendMessage(14014, &response)
+	}
+
+	if client.Commander.GetResourceCount(1) < upgrade.CoinConsume {
+		response.Result = proto.Uint32(1)
+		return client.SendMessage(14014, &response)
+	}
+	for _, cost := range upgrade.MaterialCost {
+		if client.Commander.GetItemCount(cost.ItemID) < cost.Count {
+			response.Result = proto.Uint32(1)
+			return client.SendMessage(14014, &response)
+		}
+	}
+
+	allowed, err := equipmentAllowedAtPos(entries, pos, ship, slotTypes, targetEquipID)
+	if err != nil {
+		return 0, 14013, err
+	}
+	if !allowed {
+		if client.Commander.EquipmentBagCount() >= equipBagMax {
+			response.Result = proto.Uint32(1)
+			return client.SendMessage(14014, &response)
+		}
+	}
+
+	tx := orm.GormDB.Begin()
+	if upgrade.CoinConsume != 0 {
+		if err := client.Commander.ConsumeResourceTx(tx, 1, upgrade.CoinConsume); err != nil {
+			tx.Rollback()
+			response.Result = proto.Uint32(1)
+			return client.SendMessage(14014, &response)
+		}
+	}
+	for _, cost := range upgrade.MaterialCost {
+		if err := client.Commander.ConsumeItemTx(tx, cost.ItemID, cost.Count); err != nil {
+			tx.Rollback()
+			response.Result = proto.Uint32(1)
+			return client.SendMessage(14014, &response)
+		}
+	}
+
+	if allowed {
+		current.EquipID = targetEquipID
+		current.SkinID = 0
+	} else {
+		current.EquipID = 0
+		current.SkinID = 0
+		if err := client.Commander.AddOwnedEquipmentTx(tx, targetEquipID, 1); err != nil {
+			tx.Rollback()
+			return 0, 14013, err
+		}
+	}
+	if err := orm.UpsertOwnedShipEquipmentTx(tx, current); err != nil {
+		tx.Rollback()
+		return 0, 14013, err
+	}
+	if err := tx.Commit().Error; err != nil {
+		return 0, 14013, err
+	}
+	applyShipEquipmentUpdate(ship, current)
+	return client.SendMessage(14014, &response)
+}
+
+func equipmentAllowedAtPos(entries []orm.OwnedShipEquipment, pos uint32, ship *orm.OwnedShip, slotTypes []uint32, equipmentID uint32) (bool, error) {
+	cache := make(map[uint32]*orm.Equipment)
+	equipConfig, err := resolveEquipmentConfig(cache, equipmentID)
+	if err != nil {
+		return false, err
+	}
+	if !containsUint32(slotTypes, equipConfig.Type) {
+		return false, nil
+	}
+	if isForbiddenShipType(equipConfig.ShipTypeForbidden, ship.Ship.Type) {
+		return false, nil
+	}
+	if equipConfig.EquipLimit != 0 {
+		for _, entry := range entries {
+			if entry.Pos == pos || entry.EquipID == 0 {
+				continue
+			}
+			otherConfig, err := resolveEquipmentConfig(cache, entry.EquipID)
+			if err != nil {
+				return false, err
+			}
+			if otherConfig.EquipLimit == equipConfig.EquipLimit {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}

--- a/internal/answer/transform_equipment_14013_test.go
+++ b/internal/answer/transform_equipment_14013_test.go
@@ -1,0 +1,354 @@
+package answer_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/answer"
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func setupTransformEquipmentTest(t *testing.T) *connection.Client {
+	t.Helper()
+	os.Setenv("MODE", "test")
+	orm.InitDatabase()
+	clearEquipTable(t, &orm.OwnedShipEquipment{})
+	clearEquipTable(t, &orm.OwnedShip{})
+	clearEquipTable(t, &orm.OwnedEquipment{})
+	clearEquipTable(t, &orm.CommanderItem{})
+	clearEquipTable(t, &orm.CommanderMiscItem{})
+	clearEquipTable(t, &orm.OwnedResource{})
+	clearEquipTable(t, &orm.Equipment{})
+	clearEquipTable(t, &orm.Ship{})
+	clearEquipTable(t, &orm.Resource{})
+	clearEquipTable(t, &orm.Item{})
+	clearEquipTable(t, &orm.ConfigEntry{})
+	clearEquipTable(t, &orm.Commander{})
+
+	commander := orm.Commander{CommanderID: 701, AccountID: 701, Name: "Transform Tester"}
+	if err := orm.GormDB.Create(&commander).Error; err != nil {
+		t.Fatalf("create commander: %v", err)
+	}
+	if err := commander.Load(); err != nil {
+		t.Fatalf("load commander: %v", err)
+	}
+	return &connection.Client{Commander: &commander}
+}
+
+func seedResource(t *testing.T, id uint32) {
+	t.Helper()
+	resource := orm.Resource{ID: id, Name: fmt.Sprintf("res-%d", id)}
+	if err := orm.GormDB.Create(&resource).Error; err != nil {
+		t.Fatalf("seed resource: %v", err)
+	}
+}
+
+func seedItem(t *testing.T, id uint32) {
+	t.Helper()
+	item := orm.Item{ID: id, Name: fmt.Sprintf("item-%d", id), Rarity: 1, ShopID: -2, Type: 1, VirtualType: 0}
+	if err := orm.GormDB.Create(&item).Error; err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+}
+
+func seedCommanderGold(t *testing.T, commanderID uint32, amount uint32) {
+	t.Helper()
+	if err := orm.GormDB.Create(&orm.OwnedResource{CommanderID: commanderID, ResourceID: 1, Amount: amount}).Error; err != nil {
+		t.Fatalf("seed gold: %v", err)
+	}
+}
+
+func seedCommanderItem(t *testing.T, commanderID uint32, itemID uint32, count uint32) {
+	t.Helper()
+	if err := orm.GormDB.Create(&orm.CommanderItem{CommanderID: commanderID, ItemID: itemID, Count: count}).Error; err != nil {
+		t.Fatalf("seed commander item: %v", err)
+	}
+}
+
+func seedEquipUpgradeData(t *testing.T, upgradeID uint32, upgradeFrom uint32, targetID uint32, coinConsume uint32, materials [][]uint32) {
+	t.Helper()
+	payload, err := json.Marshal(struct {
+		ID          uint32     `json:"id"`
+		UpgradeFrom uint32     `json:"upgrade_from"`
+		TargetID    uint32     `json:"target_id"`
+		CoinConsume uint32     `json:"coin_consume"`
+		Materials   [][]uint32 `json:"material_consume"`
+	}{
+		ID:          upgradeID,
+		UpgradeFrom: upgradeFrom,
+		TargetID:    targetID,
+		CoinConsume: coinConsume,
+		Materials:   materials,
+	})
+	if err != nil {
+		t.Fatalf("marshal equip upgrade data: %v", err)
+	}
+	entry := orm.ConfigEntry{Category: "ShareCfg/equip_upgrade_data.json", Key: fmt.Sprintf("%d", upgradeID), Data: payload}
+	if err := orm.GormDB.Create(&entry).Error; err != nil {
+		t.Fatalf("seed equip upgrade data: %v", err)
+	}
+}
+
+func seedEquipment(t *testing.T, id uint32, equipType uint32, equipLimit int) {
+	t.Helper()
+	equip := orm.Equipment{
+		ID:                id,
+		DestroyGold:       0,
+		DestroyItem:       json.RawMessage(`[]`),
+		EquipLimit:        equipLimit,
+		Group:             1,
+		Important:         0,
+		Level:             1,
+		Next:              0,
+		Prev:              0,
+		RestoreGold:       0,
+		RestoreItem:       json.RawMessage(`[]`),
+		ShipTypeForbidden: json.RawMessage(`[]`),
+		TransUseGold:      0,
+		TransUseItem:      json.RawMessage(`[]`),
+		Type:              equipType,
+		UpgradeFormulaID:  json.RawMessage(`[]`),
+	}
+	if err := orm.GormDB.Create(&equip).Error; err != nil {
+		t.Fatalf("seed equipment: %v", err)
+	}
+}
+
+func sendCS14013(t *testing.T, client *connection.Client, shipID uint32, pos uint32, upgradeID uint32) *protobuf.SC_14014 {
+	t.Helper()
+	payload := protobuf.CS_14013{
+		ShipId:    proto.Uint32(shipID),
+		Pos:       proto.Uint32(pos),
+		UpgradeId: proto.Uint32(upgradeID),
+	}
+	buf, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	client.Buffer.Reset()
+	if _, _, err := answer.TransformEquipmentOnShip14013(&buf, client); err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+	response := &protobuf.SC_14014{}
+	decodePacket(t, client, 14014, response)
+	return response
+}
+
+func TestTransformEquipmentOnShipSuccessAllowed(t *testing.T) {
+	client := setupTransformEquipmentTest(t)
+	seedResource(t, 1)
+	seedItem(t, 3001)
+	seedCommanderGold(t, client.Commander.CommanderID, 200)
+	seedCommanderItem(t, client.Commander.CommanderID, 3001, 2)
+
+	ship := orm.Ship{TemplateID: 1001, Name: "Ship", EnglishName: "Ship", RarityID: 2, Star: 1, Type: 1, Nationality: 1, BuildTime: 10}
+	if err := orm.GormDB.Create(&ship).Error; err != nil {
+		t.Fatalf("create ship: %v", err)
+	}
+	seedShipEquipConfig(t, 1001, `{"id":1001,"equip_1":[1],"equip_2":[],"equip_3":[],"equip_4":[],"equip_5":[],"equip_id_1":2001,"equip_id_2":0,"equip_id_3":0}`)
+	seedEquipment(t, 2001, 1, 0)
+	seedEquipment(t, 2002, 1, 0)
+	seedEquipUpgradeData(t, 9001, 2001, 2002, 100, [][]uint32{{3001, 2}})
+
+	ownedShip, err := client.Commander.AddShip(1001)
+	if err != nil {
+		t.Fatalf("add ship: %v", err)
+	}
+	if err := client.Commander.Load(); err != nil {
+		t.Fatalf("reload commander: %v", err)
+	}
+
+	resp := sendCS14013(t, client, ownedShip.ID, 1, 9001)
+	if resp.GetResult() != 0 {
+		t.Fatalf("expected success result")
+	}
+	var entry orm.OwnedShipEquipment
+	if err := orm.GormDB.Where("owner_id = ? AND ship_id = ? AND pos = ?", client.Commander.CommanderID, ownedShip.ID, 1).First(&entry).Error; err != nil {
+		t.Fatalf("load ship equipment: %v", err)
+	}
+	if entry.EquipID != 2002 {
+		t.Fatalf("expected equip id 2002, got %d", entry.EquipID)
+	}
+	if client.Commander.GetResourceCount(1) != 100 {
+		t.Fatalf("expected gold 100, got %d", client.Commander.GetResourceCount(1))
+	}
+	if client.Commander.GetItemCount(3001) != 0 {
+		t.Fatalf("expected item count 0, got %d", client.Commander.GetItemCount(3001))
+	}
+}
+
+func TestTransformEquipmentOnShipFailsWrongUpgradePath(t *testing.T) {
+	client := setupTransformEquipmentTest(t)
+	seedResource(t, 1)
+	seedItem(t, 3001)
+	seedCommanderGold(t, client.Commander.CommanderID, 200)
+	seedCommanderItem(t, client.Commander.CommanderID, 3001, 2)
+
+	ship := orm.Ship{TemplateID: 1001, Name: "Ship", EnglishName: "Ship", RarityID: 2, Star: 1, Type: 1, Nationality: 1, BuildTime: 10}
+	if err := orm.GormDB.Create(&ship).Error; err != nil {
+		t.Fatalf("create ship: %v", err)
+	}
+	seedShipEquipConfig(t, 1001, `{"id":1001,"equip_1":[1],"equip_2":[],"equip_3":[],"equip_4":[],"equip_5":[],"equip_id_1":2003,"equip_id_2":0,"equip_id_3":0}`)
+	seedEquipment(t, 2003, 1, 0)
+	seedEquipment(t, 2002, 1, 0)
+	seedEquipUpgradeData(t, 9001, 2001, 2002, 100, [][]uint32{{3001, 2}})
+
+	ownedShip, err := client.Commander.AddShip(1001)
+	if err != nil {
+		t.Fatalf("add ship: %v", err)
+	}
+	if err := client.Commander.Load(); err != nil {
+		t.Fatalf("reload commander: %v", err)
+	}
+	goldBefore := client.Commander.GetResourceCount(1)
+	itemBefore := client.Commander.GetItemCount(3001)
+
+	resp := sendCS14013(t, client, ownedShip.ID, 1, 9001)
+	if resp.GetResult() == 0 {
+		t.Fatalf("expected failure")
+	}
+	var entry orm.OwnedShipEquipment
+	if err := orm.GormDB.Where("owner_id = ? AND ship_id = ? AND pos = ?", client.Commander.CommanderID, ownedShip.ID, 1).First(&entry).Error; err != nil {
+		t.Fatalf("load ship equipment: %v", err)
+	}
+	if entry.EquipID != 2003 {
+		t.Fatalf("expected equip id 2003, got %d", entry.EquipID)
+	}
+	if client.Commander.GetResourceCount(1) != goldBefore {
+		t.Fatalf("expected gold unchanged")
+	}
+	if client.Commander.GetItemCount(3001) != itemBefore {
+		t.Fatalf("expected items unchanged")
+	}
+}
+
+func TestTransformEquipmentOnShipFailsInsufficientGold(t *testing.T) {
+	client := setupTransformEquipmentTest(t)
+	seedResource(t, 1)
+	seedItem(t, 3001)
+	seedCommanderGold(t, client.Commander.CommanderID, 50)
+	seedCommanderItem(t, client.Commander.CommanderID, 3001, 2)
+
+	ship := orm.Ship{TemplateID: 1001, Name: "Ship", EnglishName: "Ship", RarityID: 2, Star: 1, Type: 1, Nationality: 1, BuildTime: 10}
+	if err := orm.GormDB.Create(&ship).Error; err != nil {
+		t.Fatalf("create ship: %v", err)
+	}
+	seedShipEquipConfig(t, 1001, `{"id":1001,"equip_1":[1],"equip_2":[],"equip_3":[],"equip_4":[],"equip_5":[],"equip_id_1":2001,"equip_id_2":0,"equip_id_3":0}`)
+	seedEquipment(t, 2001, 1, 0)
+	seedEquipment(t, 2002, 1, 0)
+	seedEquipUpgradeData(t, 9001, 2001, 2002, 100, [][]uint32{{3001, 2}})
+
+	ownedShip, err := client.Commander.AddShip(1001)
+	if err != nil {
+		t.Fatalf("add ship: %v", err)
+	}
+	if err := client.Commander.Load(); err != nil {
+		t.Fatalf("reload commander: %v", err)
+	}
+
+	resp := sendCS14013(t, client, ownedShip.ID, 1, 9001)
+	if resp.GetResult() == 0 {
+		t.Fatalf("expected failure")
+	}
+	var entry orm.OwnedShipEquipment
+	if err := orm.GormDB.Where("owner_id = ? AND ship_id = ? AND pos = ?", client.Commander.CommanderID, ownedShip.ID, 1).First(&entry).Error; err != nil {
+		t.Fatalf("load ship equipment: %v", err)
+	}
+	if entry.EquipID != 2001 {
+		t.Fatalf("expected equip unchanged")
+	}
+	if client.Commander.GetResourceCount(1) != 50 {
+		t.Fatalf("expected gold unchanged")
+	}
+}
+
+func TestTransformEquipmentOnShipMovesToBagWhenForbidden(t *testing.T) {
+	client := setupTransformEquipmentTest(t)
+	seedResource(t, 1)
+	seedItem(t, 3001)
+	seedCommanderGold(t, client.Commander.CommanderID, 200)
+	seedCommanderItem(t, client.Commander.CommanderID, 3001, 2)
+
+	ship := orm.Ship{TemplateID: 1001, Name: "Ship", EnglishName: "Ship", RarityID: 2, Star: 1, Type: 1, Nationality: 1, BuildTime: 10}
+	if err := orm.GormDB.Create(&ship).Error; err != nil {
+		t.Fatalf("create ship: %v", err)
+	}
+	seedShipEquipConfig(t, 1001, `{"id":1001,"equip_1":[1],"equip_2":[],"equip_3":[],"equip_4":[],"equip_5":[],"equip_id_1":2001,"equip_id_2":0,"equip_id_3":0}`)
+	seedEquipment(t, 2001, 1, 0)
+	seedEquipment(t, 2002, 2, 0)
+	seedEquipUpgradeData(t, 9001, 2001, 2002, 100, [][]uint32{{3001, 2}})
+
+	ownedShip, err := client.Commander.AddShip(1001)
+	if err != nil {
+		t.Fatalf("add ship: %v", err)
+	}
+	if err := client.Commander.Load(); err != nil {
+		t.Fatalf("reload commander: %v", err)
+	}
+
+	resp := sendCS14013(t, client, ownedShip.ID, 1, 9001)
+	if resp.GetResult() != 0 {
+		t.Fatalf("expected success")
+	}
+	var entry orm.OwnedShipEquipment
+	if err := orm.GormDB.Where("owner_id = ? AND ship_id = ? AND pos = ?", client.Commander.CommanderID, ownedShip.ID, 1).First(&entry).Error; err != nil {
+		t.Fatalf("load ship equipment: %v", err)
+	}
+	if entry.EquipID != 0 {
+		t.Fatalf("expected slot to be cleared")
+	}
+	owned := client.Commander.GetOwnedEquipment(2002)
+	if owned == nil || owned.Count != 1 {
+		t.Fatalf("expected upgraded equipment to be added to bag")
+	}
+}
+
+func TestTransformEquipmentOnShipFailsInsufficientMaterial(t *testing.T) {
+	client := setupTransformEquipmentTest(t)
+	seedResource(t, 1)
+	seedItem(t, 3001)
+	seedCommanderGold(t, client.Commander.CommanderID, 200)
+	seedCommanderItem(t, client.Commander.CommanderID, 3001, 1)
+
+	ship := orm.Ship{TemplateID: 1001, Name: "Ship", EnglishName: "Ship", RarityID: 2, Star: 1, Type: 1, Nationality: 1, BuildTime: 10}
+	if err := orm.GormDB.Create(&ship).Error; err != nil {
+		t.Fatalf("create ship: %v", err)
+	}
+	seedShipEquipConfig(t, 1001, `{"id":1001,"equip_1":[1],"equip_2":[],"equip_3":[],"equip_4":[],"equip_5":[],"equip_id_1":2001,"equip_id_2":0,"equip_id_3":0}`)
+	seedEquipment(t, 2001, 1, 0)
+	seedEquipment(t, 2002, 1, 0)
+	seedEquipUpgradeData(t, 9001, 2001, 2002, 100, [][]uint32{{3001, 2}})
+
+	ownedShip, err := client.Commander.AddShip(1001)
+	if err != nil {
+		t.Fatalf("add ship: %v", err)
+	}
+	if err := client.Commander.Load(); err != nil {
+		t.Fatalf("reload commander: %v", err)
+	}
+	goldBefore := client.Commander.GetResourceCount(1)
+	itemBefore := client.Commander.GetItemCount(3001)
+
+	resp := sendCS14013(t, client, ownedShip.ID, 1, 9001)
+	if resp.GetResult() == 0 {
+		t.Fatalf("expected failure")
+	}
+	var entry orm.OwnedShipEquipment
+	if err := orm.GormDB.Where("owner_id = ? AND ship_id = ? AND pos = ?", client.Commander.CommanderID, ownedShip.ID, 1).First(&entry).Error; err != nil {
+		t.Fatalf("load ship equipment: %v", err)
+	}
+	if entry.EquipID != 2001 {
+		t.Fatalf("expected equip unchanged")
+	}
+	if client.Commander.GetResourceCount(1) != goldBefore {
+		t.Fatalf("expected gold unchanged")
+	}
+	if client.Commander.GetItemCount(3001) != itemBefore {
+		t.Fatalf("expected items unchanged")
+	}
+}

--- a/internal/answer/transform_equipment_14015.go
+++ b/internal/answer/transform_equipment_14015.go
@@ -1,0 +1,88 @@
+package answer
+
+import (
+	"errors"
+
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+	"gorm.io/gorm"
+)
+
+func TransformEquipmentInBag14015(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var data protobuf.CS_14015
+	if err := proto.Unmarshal(*buffer, &data); err != nil {
+		return 0, 14015, err
+	}
+
+	response := protobuf.SC_14016{Result: proto.Uint32(0)}
+	equipID := data.GetEquipId()
+	if equipID == 0 {
+		response.Result = proto.Uint32(1)
+		return client.SendMessage(14016, &response)
+	}
+	owned := client.Commander.GetOwnedEquipment(equipID)
+	if owned == nil || owned.Count == 0 {
+		response.Result = proto.Uint32(1)
+		return client.SendMessage(14016, &response)
+	}
+
+	upgrade, err := orm.GetEquipUpgradeDataTx(orm.GormDB, data.GetUpgradeId())
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			response.Result = proto.Uint32(1)
+			return client.SendMessage(14016, &response)
+		}
+		return 0, 14015, err
+	}
+	if upgrade.UpgradeFrom != equipID {
+		response.Result = proto.Uint32(1)
+		return client.SendMessage(14016, &response)
+	}
+	targetEquipID := upgrade.TargetID
+	if targetEquipID == 0 {
+		response.Result = proto.Uint32(1)
+		return client.SendMessage(14016, &response)
+	}
+
+	if client.Commander.GetResourceCount(1) < upgrade.CoinConsume {
+		response.Result = proto.Uint32(1)
+		return client.SendMessage(14016, &response)
+	}
+	for _, cost := range upgrade.MaterialCost {
+		if client.Commander.GetItemCount(cost.ItemID) < cost.Count {
+			response.Result = proto.Uint32(1)
+			return client.SendMessage(14016, &response)
+		}
+	}
+
+	tx := orm.GormDB.Begin()
+	if upgrade.CoinConsume != 0 {
+		if err := client.Commander.ConsumeResourceTx(tx, 1, upgrade.CoinConsume); err != nil {
+			tx.Rollback()
+			response.Result = proto.Uint32(1)
+			return client.SendMessage(14016, &response)
+		}
+	}
+	for _, cost := range upgrade.MaterialCost {
+		if err := client.Commander.ConsumeItemTx(tx, cost.ItemID, cost.Count); err != nil {
+			tx.Rollback()
+			response.Result = proto.Uint32(1)
+			return client.SendMessage(14016, &response)
+		}
+	}
+	if err := client.Commander.RemoveOwnedEquipmentTx(tx, equipID, 1); err != nil {
+		tx.Rollback()
+		response.Result = proto.Uint32(1)
+		return client.SendMessage(14016, &response)
+	}
+	if err := client.Commander.AddOwnedEquipmentTx(tx, targetEquipID, 1); err != nil {
+		tx.Rollback()
+		return 0, 14015, err
+	}
+	if err := tx.Commit().Error; err != nil {
+		return 0, 14015, err
+	}
+	return client.SendMessage(14016, &response)
+}

--- a/internal/answer/transform_equipment_14015_test.go
+++ b/internal/answer/transform_equipment_14015_test.go
@@ -1,0 +1,156 @@
+package answer_test
+
+import (
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/answer"
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func sendCS14015(t *testing.T, client *connection.Client, equipID uint32, upgradeID uint32) *protobuf.SC_14016 {
+	t.Helper()
+	payload := protobuf.CS_14015{
+		EquipId:   proto.Uint32(equipID),
+		UpgradeId: proto.Uint32(upgradeID),
+	}
+	buf, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	client.Buffer.Reset()
+	if _, _, err := answer.TransformEquipmentInBag14015(&buf, client); err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+	response := &protobuf.SC_14016{}
+	decodePacket(t, client, 14016, response)
+	return response
+}
+
+func TestTransformEquipmentInBagSuccess(t *testing.T) {
+	client := setupTransformEquipmentTest(t)
+	seedResource(t, 1)
+	seedItem(t, 3001)
+	seedCommanderGold(t, client.Commander.CommanderID, 200)
+	seedCommanderItem(t, client.Commander.CommanderID, 3001, 2)
+	seedEquipment(t, 2001, 1, 0)
+	seedEquipment(t, 2002, 1, 0)
+	seedEquipUpgradeData(t, 9001, 2001, 2002, 100, [][]uint32{{3001, 2}})
+
+	if err := orm.GormDB.Create(&orm.OwnedEquipment{CommanderID: client.Commander.CommanderID, EquipmentID: 2001, Count: 1}).Error; err != nil {
+		t.Fatalf("seed owned equipment: %v", err)
+	}
+	if err := client.Commander.Load(); err != nil {
+		t.Fatalf("reload commander: %v", err)
+	}
+
+	resp := sendCS14015(t, client, 2001, 9001)
+	if resp.GetResult() != 0 {
+		t.Fatalf("expected success")
+	}
+	if client.Commander.GetOwnedEquipment(2001) != nil {
+		t.Fatalf("expected source equipment removed")
+	}
+	owned := client.Commander.GetOwnedEquipment(2002)
+	if owned == nil || owned.Count != 1 {
+		t.Fatalf("expected target equipment added")
+	}
+}
+
+func TestTransformEquipmentInBagFailsWrongUpgradePath(t *testing.T) {
+	client := setupTransformEquipmentTest(t)
+	seedResource(t, 1)
+	seedItem(t, 3001)
+	seedCommanderGold(t, client.Commander.CommanderID, 200)
+	seedCommanderItem(t, client.Commander.CommanderID, 3001, 2)
+	seedEquipment(t, 2001, 1, 0)
+	seedEquipment(t, 2002, 1, 0)
+	seedEquipUpgradeData(t, 9001, 9999, 2002, 100, [][]uint32{{3001, 2}})
+
+	if err := orm.GormDB.Create(&orm.OwnedEquipment{CommanderID: client.Commander.CommanderID, EquipmentID: 2001, Count: 1}).Error; err != nil {
+		t.Fatalf("seed owned equipment: %v", err)
+	}
+	if err := client.Commander.Load(); err != nil {
+		t.Fatalf("reload commander: %v", err)
+	}
+	goldBefore := client.Commander.GetResourceCount(1)
+	itemBefore := client.Commander.GetItemCount(3001)
+
+	resp := sendCS14015(t, client, 2001, 9001)
+	if resp.GetResult() == 0 {
+		t.Fatalf("expected failure")
+	}
+	owned := client.Commander.GetOwnedEquipment(2001)
+	if owned == nil || owned.Count != 1 {
+		t.Fatalf("expected equipment unchanged")
+	}
+	if client.Commander.GetResourceCount(1) != goldBefore {
+		t.Fatalf("expected gold unchanged")
+	}
+	if client.Commander.GetItemCount(3001) != itemBefore {
+		t.Fatalf("expected items unchanged")
+	}
+}
+
+func TestTransformEquipmentInBagFailsInsufficientGold(t *testing.T) {
+	client := setupTransformEquipmentTest(t)
+	seedResource(t, 1)
+	seedItem(t, 3001)
+	seedCommanderGold(t, client.Commander.CommanderID, 10)
+	seedCommanderItem(t, client.Commander.CommanderID, 3001, 2)
+	seedEquipment(t, 2001, 1, 0)
+	seedEquipment(t, 2002, 1, 0)
+	seedEquipUpgradeData(t, 9001, 2001, 2002, 100, [][]uint32{{3001, 2}})
+
+	if err := orm.GormDB.Create(&orm.OwnedEquipment{CommanderID: client.Commander.CommanderID, EquipmentID: 2001, Count: 1}).Error; err != nil {
+		t.Fatalf("seed owned equipment: %v", err)
+	}
+	if err := client.Commander.Load(); err != nil {
+		t.Fatalf("reload commander: %v", err)
+	}
+
+	resp := sendCS14015(t, client, 2001, 9001)
+	if resp.GetResult() == 0 {
+		t.Fatalf("expected failure")
+	}
+	if client.Commander.GetOwnedEquipment(2001) == nil {
+		t.Fatalf("expected equipment unchanged")
+	}
+}
+
+func TestTransformEquipmentInBagFailsInsufficientMaterial(t *testing.T) {
+	client := setupTransformEquipmentTest(t)
+	seedResource(t, 1)
+	seedItem(t, 3001)
+	seedCommanderGold(t, client.Commander.CommanderID, 200)
+	seedCommanderItem(t, client.Commander.CommanderID, 3001, 1)
+	seedEquipment(t, 2001, 1, 0)
+	seedEquipment(t, 2002, 1, 0)
+	seedEquipUpgradeData(t, 9001, 2001, 2002, 100, [][]uint32{{3001, 2}})
+
+	if err := orm.GormDB.Create(&orm.OwnedEquipment{CommanderID: client.Commander.CommanderID, EquipmentID: 2001, Count: 1}).Error; err != nil {
+		t.Fatalf("seed owned equipment: %v", err)
+	}
+	if err := client.Commander.Load(); err != nil {
+		t.Fatalf("reload commander: %v", err)
+	}
+	goldBefore := client.Commander.GetResourceCount(1)
+	itemBefore := client.Commander.GetItemCount(3001)
+
+	resp := sendCS14015(t, client, 2001, 9001)
+	if resp.GetResult() == 0 {
+		t.Fatalf("expected failure")
+	}
+	owned := client.Commander.GetOwnedEquipment(2001)
+	if owned == nil || owned.Count != 1 {
+		t.Fatalf("expected equipment unchanged")
+	}
+	if client.Commander.GetResourceCount(1) != goldBefore {
+		t.Fatalf("expected gold unchanged")
+	}
+	if client.Commander.GetItemCount(3001) != itemBefore {
+		t.Fatalf("expected items unchanged")
+	}
+}

--- a/internal/entrypoint/packet_registry.go
+++ b/internal/entrypoint/packet_registry.go
@@ -239,6 +239,8 @@ func registerPackets() {
 	packets.RegisterPacketHandler(12212, []packets.PacketHandler{answer.GetPhantomQuestProgress})
 	packets.RegisterPacketHandler(14008, []packets.PacketHandler{answer.DestroyEquipments})
 	packets.RegisterPacketHandler(14010, []packets.PacketHandler{answer.RevertEquipment})
+	packets.RegisterPacketHandler(14013, []packets.PacketHandler{answer.TransformEquipmentOnShip14013})
+	packets.RegisterPacketHandler(14015, []packets.PacketHandler{answer.TransformEquipmentInBag14015})
 	packets.RegisterPacketHandler(14209, []packets.PacketHandler{answer.CompositeSpWeapon})
 	packets.RegisterPacketHandler(12301, []packets.PacketHandler{answer.ReqPlayerAssistShip})
 	packets.RegisterPacketHandler(12034, []packets.PacketHandler{answer.RenameProposedShip})

--- a/internal/misc/update_data.go
+++ b/internal/misc/update_data.go
@@ -141,6 +141,7 @@ func importConfigEntries(region string, tx *gorm.DB) error {
 			"ShareCfg/ship_strengthen_blueprint.json",
 			"ShareCfg/ship_strengthen_meta.json",
 			"ShareCfg/transform_data_template.json",
+			"ShareCfg/equip_upgrade_data.json",
 			"ShareCfg/month_shop_template.json",
 			"ShareCfg/newserver_shop_template.json",
 			"ShareCfg/blackfriday_shop_template.json",

--- a/internal/orm/equip_upgrade_data.go
+++ b/internal/orm/equip_upgrade_data.go
@@ -1,0 +1,70 @@
+package orm
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+
+	"gorm.io/gorm"
+)
+
+const equipUpgradeCategory = "ShareCfg/equip_upgrade_data.json"
+
+type EquipUpgradeMaterial struct {
+	ItemID uint32
+	Count  uint32
+}
+
+type EquipUpgradeData struct {
+	ID           uint32
+	UpgradeFrom  uint32
+	TargetID     uint32
+	CoinConsume  uint32
+	MaterialCost []EquipUpgradeMaterial
+}
+
+func GetEquipUpgradeDataTx(db *gorm.DB, upgradeID uint32) (*EquipUpgradeData, error) {
+	entry, err := GetConfigEntry(db, equipUpgradeCategory, strconv.FormatUint(uint64(upgradeID), 10))
+	if err != nil {
+		return nil, err
+	}
+	var raw struct {
+		ID          uint32          `json:"id"`
+		UpgradeFrom uint32          `json:"upgrade_from"`
+		TargetID    uint32          `json:"target_id"`
+		CoinConsume uint32          `json:"coin_consume"`
+		Materials   json.RawMessage `json:"material_consume"`
+	}
+	if err := json.Unmarshal(entry.Data, &raw); err != nil {
+		return nil, err
+	}
+	materials, err := parseEquipUpgradeMaterials(raw.Materials)
+	if err != nil {
+		return nil, err
+	}
+	return &EquipUpgradeData{
+		ID:           raw.ID,
+		UpgradeFrom:  raw.UpgradeFrom,
+		TargetID:     raw.TargetID,
+		CoinConsume:  raw.CoinConsume,
+		MaterialCost: materials,
+	}, nil
+}
+
+func parseEquipUpgradeMaterials(raw json.RawMessage) ([]EquipUpgradeMaterial, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var pairs [][]uint32
+	if err := json.Unmarshal(raw, &pairs); err != nil {
+		return nil, err
+	}
+	materials := make([]EquipUpgradeMaterial, 0, len(pairs))
+	for _, pair := range pairs {
+		if len(pair) != 2 {
+			return nil, errors.New("invalid equip upgrade material_consume")
+		}
+		materials = append(materials, EquipUpgradeMaterial{ItemID: pair[0], Count: pair[1]})
+	}
+	return materials, nil
+}

--- a/internal/orm/equip_upgrade_data_test.go
+++ b/internal/orm/equip_upgrade_data_test.go
@@ -1,0 +1,52 @@
+package orm
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGetEquipUpgradeDataTxLoadsConfigEntry(t *testing.T) {
+	initCommanderItemTestDB(t)
+	clearTable(t, &ConfigEntry{})
+
+	entry := ConfigEntry{
+		Category: equipUpgradeCategory,
+		Key:      "9001",
+		Data:     json.RawMessage(`{"id":9001,"upgrade_from":2001,"target_id":2002,"coin_consume":120,"material_consume":[[3001,2],[3002,4]]}`),
+	}
+	if err := GormDB.Create(&entry).Error; err != nil {
+		t.Fatalf("seed equip upgrade entry: %v", err)
+	}
+
+	data, err := GetEquipUpgradeDataTx(GormDB, 9001)
+	if err != nil {
+		t.Fatalf("get equip upgrade data: %v", err)
+	}
+	if data.ID != 9001 || data.UpgradeFrom != 2001 || data.TargetID != 2002 {
+		t.Fatalf("unexpected ids: %+v", data)
+	}
+	if data.CoinConsume != 120 {
+		t.Fatalf("expected coin consume 120, got %d", data.CoinConsume)
+	}
+	if len(data.MaterialCost) != 2 || data.MaterialCost[0].ItemID != 3001 || data.MaterialCost[0].Count != 2 {
+		t.Fatalf("unexpected materials: %+v", data.MaterialCost)
+	}
+}
+
+func TestGetEquipUpgradeDataTxRejectsInvalidMaterials(t *testing.T) {
+	initCommanderItemTestDB(t)
+	clearTable(t, &ConfigEntry{})
+
+	entry := ConfigEntry{
+		Category: equipUpgradeCategory,
+		Key:      "9002",
+		Data:     json.RawMessage(`{"id":9002,"upgrade_from":2001,"target_id":2002,"coin_consume":0,"material_consume":[[3001]]}`),
+	}
+	if err := GormDB.Create(&entry).Error; err != nil {
+		t.Fatalf("seed equip upgrade entry: %v", err)
+	}
+
+	if _, err := GetEquipUpgradeDataTx(GormDB, 9002); err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
# Summary
- Accept equipment upgrade transforms for equipped slots and equipment bag entries.
- Apply upgrade costs (gold + materials) using equip-upgrade config data.
- Persist ship slot changes and ensure invalid post-upgrade equips move into the equipment bag.

# Changes
- Register new packet handlers for the transform operations.
- Import equip-upgrade config entries and add an ORM loader for individual upgrade records.
- Add handlers for equipped-slot and bag transforms with shared restriction logic.
- Add unit tests covering success, validation failures, and forbidden-slot behavior.
