### PR TITLE
feat: handle billboard rank list packets

### DIFF
--- a/internal/answer/billboard_rank_list.go
+++ b/internal/answer/billboard_rank_list.go
@@ -1,0 +1,92 @@
+package answer
+
+import (
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// Client expects roughly 20 rows per page; we return at most one.
+	billboardRankSupportedMaxType = 50
+
+	// Minimal implementation: return a coherent single-row leaderboard.
+	billboardRankPoint = 1
+	billboardRankRank  = 1
+)
+
+func BillboardRankListPage(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var payload protobuf.CS_18201
+	if err := proto.Unmarshal(*buffer, &payload); err != nil {
+		response := protobuf.SC_18202{List: []*protobuf.RANK_INFO_P18{}}
+		return client.SendMessage(18202, &response)
+	}
+
+	page := payload.GetPage()
+	rankType := payload.GetType()
+	if page != 1 || !isSupportedBillboardRankType(rankType) {
+		response := protobuf.SC_18202{List: []*protobuf.RANK_INFO_P18{}}
+		return client.SendMessage(18202, &response)
+	}
+
+	row := billboardRankRow(client.Commander)
+	response := protobuf.SC_18202{List: []*protobuf.RANK_INFO_P18{row}}
+	return client.SendMessage(18202, &response)
+}
+
+func BillboardMyRank(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var payload protobuf.CS_18203
+	if err := proto.Unmarshal(*buffer, &payload); err != nil {
+		response := protobuf.SC_18204{Point: proto.Uint32(0), Rank: proto.Uint32(0)}
+		return client.SendMessage(18204, &response)
+	}
+
+	rankType := payload.GetType()
+	if !isSupportedBillboardRankType(rankType) {
+		response := protobuf.SC_18204{Point: proto.Uint32(0), Rank: proto.Uint32(0)}
+		return client.SendMessage(18204, &response)
+	}
+
+	response := protobuf.SC_18204{Point: proto.Uint32(billboardRankPoint), Rank: proto.Uint32(billboardRankRank)}
+	return client.SendMessage(18204, &response)
+}
+
+func isSupportedBillboardRankType(rankType uint32) bool {
+	// Client sends small numeric constants (PowerRank.TYPE_*). Keep this bounded so unknown
+	// types return empty responses.
+	return rankType >= 1 && rankType <= billboardRankSupportedMaxType
+}
+
+func billboardRankRow(commander *orm.Commander) *protobuf.RANK_INFO_P18 {
+	return &protobuf.RANK_INFO_P18{
+		UserId:    proto.Uint32(commander.CommanderID),
+		Point:     proto.Uint32(billboardRankPoint),
+		Name:      proto.String(commander.Name),
+		Lv:        proto.Uint32(uint32(commander.Level)),
+		ArenaRank: proto.Uint32(billboardRankRank),
+		Display:   billboardRankDisplay(commander),
+	}
+}
+
+func billboardRankDisplay(commander *orm.Commander) *protobuf.DISPLAYINFO {
+	icon := commander.DisplayIconID
+	skin := commander.DisplaySkinID
+	secretaries := commander.GetSecretaries()
+	if icon == 0 && len(secretaries) > 0 {
+		icon = secretaries[0].ShipID
+	}
+	if skin == 0 && len(secretaries) > 0 {
+		skin = secretaries[0].SkinID
+	}
+
+	return &protobuf.DISPLAYINFO{
+		Icon:          proto.Uint32(icon),
+		Skin:          proto.Uint32(skin),
+		IconFrame:     proto.Uint32(commander.SelectedIconFrameID),
+		ChatFrame:     proto.Uint32(commander.SelectedChatFrameID),
+		IconTheme:     proto.Uint32(commander.DisplayIconThemeID),
+		MarryFlag:     proto.Uint32(0),
+		TransformFlag: proto.Uint32(0),
+	}
+}

--- a/internal/answer/billboard_rank_list_test.go
+++ b/internal/answer/billboard_rank_list_test.go
@@ -1,0 +1,131 @@
+package answer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func seedSecretaryShip(t *testing.T, commander *orm.Commander, templateID uint32) {
+	t.Helper()
+	seedShipTemplate(t, templateID, 0, 5, 1, "Secretary", 6)
+	ship := orm.OwnedShip{
+		OwnerID:           commander.CommanderID,
+		ShipID:            templateID,
+		IsSecretary:       true,
+		SecretaryPosition: proto.Uint32(0),
+	}
+	if err := orm.GormDB.Create(&ship).Error; err != nil {
+		t.Fatalf("seed secretary ship: %v", err)
+	}
+	if err := commander.Load(); err != nil {
+		t.Fatalf("reload commander: %v", err)
+	}
+}
+
+func TestBillboardRankListPageReturnsRow(t *testing.T) {
+	client := setupHandlerCommander(t)
+	seedSecretaryShip(t, client.Commander, 202124)
+
+	payload := &protobuf.CS_18201{
+		Page: proto.Uint32(1),
+		Type: proto.Uint32(1),
+	}
+	buf, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	client.Buffer.Reset()
+	if _, _, err := BillboardRankListPage(&buf, client); err != nil {
+		t.Fatalf("BillboardRankListPage failed: %v", err)
+	}
+
+	var response protobuf.SC_18202
+	decodeRegisterResponse(t, client, 18202, &response)
+	if len(response.GetList()) == 0 {
+		t.Fatalf("expected at least one rank row")
+	}
+	if len(response.GetList()) > 20 {
+		t.Fatalf("expected <= 20 rows, got %d", len(response.GetList()))
+	}
+
+	row := response.GetList()[0]
+	if row.UserId == nil || row.Point == nil || row.Name == nil || row.Lv == nil || row.ArenaRank == nil {
+		t.Fatalf("expected required fields to be set")
+	}
+	if row.Display == nil {
+		t.Fatalf("expected display block")
+	}
+	if row.Display.Icon == nil || row.Display.Skin == nil || row.Display.IconFrame == nil || row.Display.ChatFrame == nil || row.Display.IconTheme == nil || row.Display.MarryFlag == nil || row.Display.TransformFlag == nil {
+		t.Fatalf("expected display subfields to be set")
+	}
+}
+
+func TestBillboardMyRankReturnsRankAndPoint(t *testing.T) {
+	client := setupHandlerCommander(t)
+	seedSecretaryShip(t, client.Commander, 202124)
+	client.Commander.Level = 10
+	client.Commander.LastLogin = time.Now().UTC()
+	if err := orm.GormDB.Save(client.Commander).Error; err != nil {
+		t.Fatalf("save commander: %v", err)
+	}
+
+	payload := &protobuf.CS_18203{Type: proto.Uint32(1)}
+	buf, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	client.Buffer.Reset()
+	if _, _, err := BillboardMyRank(&buf, client); err != nil {
+		t.Fatalf("BillboardMyRank failed: %v", err)
+	}
+
+	var response protobuf.SC_18204
+	decodeRegisterResponse(t, client, 18204, &response)
+	if response.Point == nil || response.Rank == nil {
+		t.Fatalf("expected point and rank fields")
+	}
+	if response.GetRank() == 0 {
+		t.Fatalf("expected a non-zero rank")
+	}
+}
+
+func TestBillboardRankUnknownTypeReturnsEmptyAndZeroRank(t *testing.T) {
+	client := setupHandlerCommander(t)
+	seedSecretaryShip(t, client.Commander, 202124)
+
+	pagePayload := &protobuf.CS_18201{Page: proto.Uint32(1), Type: proto.Uint32(999)}
+	buf, err := proto.Marshal(pagePayload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	client.Buffer.Reset()
+	if _, _, err := BillboardRankListPage(&buf, client); err != nil {
+		t.Fatalf("BillboardRankListPage failed: %v", err)
+	}
+	var pageResp protobuf.SC_18202
+	decodeRegisterResponse(t, client, 18202, &pageResp)
+	if len(pageResp.GetList()) != 0 {
+		t.Fatalf("expected empty list")
+	}
+
+	myPayload := &protobuf.CS_18203{Type: proto.Uint32(999)}
+	buf, err = proto.Marshal(myPayload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	client.Buffer.Reset()
+	if _, _, err := BillboardMyRank(&buf, client); err != nil {
+		t.Fatalf("BillboardMyRank failed: %v", err)
+	}
+	var myResp protobuf.SC_18204
+	decodeRegisterResponse(t, client, 18204, &myResp)
+	if myResp.GetRank() != 0 || myResp.GetPoint() != 0 {
+		t.Fatalf("expected rank=0 and point=0")
+	}
+}

--- a/internal/entrypoint/packet_registry.go
+++ b/internal/entrypoint/packet_registry.go
@@ -80,6 +80,8 @@ func registerPackets() {
 	packets.RegisterPacketHandler(18100, []packets.PacketHandler{answer.GetArenaShop})
 	packets.RegisterPacketHandler(18102, []packets.PacketHandler{answer.RefreshArenaShop})
 	packets.RegisterPacketHandler(18104, []packets.PacketHandler{answer.GetRivalInfo})
+	packets.RegisterPacketHandler(18201, []packets.PacketHandler{answer.BillboardRankListPage})
+	packets.RegisterPacketHandler(18203, []packets.PacketHandler{answer.BillboardMyRank})
 	packets.RegisterPacketHandler(60033, []packets.PacketHandler{answer.GetGuildShop})
 	packets.RegisterPacketHandler(16106, []packets.PacketHandler{answer.GetMedalShop})
 	packets.RegisterPacketHandler(60037, []packets.PacketHandler{answer.CommanderGuildData})


### PR DESCRIPTION
## Summary
- Register handlers for `CS_18201` (rank list page) and `CS_18203` (my rank) to avoid missing-handler stalls.
- Return minimal but well-formed `SC_18202`/`SC_18204` payloads (page 1 only; supported rank types return a single self row).
- Add unit tests covering supported/unsupported type behavior.