### PR TITLE
docs: document sc_12042 missing-handler behavior

### DIFF
--- a/specs/SC_12042.md
+++ b/specs/SC_12042.md
@@ -1,0 +1,40 @@
+# SC_12042 (ship list)
+
+Packet id `12042` has an outbound protobuf type (`SC_12042`) in this repo, but there is no corresponding inbound handler registered for `CS_12042`.
+
+## Current server behavior
+
+### CS_12042 (inbound)
+
+- Registration: no `RegisterPacketHandler(12042, ...)` entry exists in `internal/entrypoint/packet_registry.go`.
+- Dispatch path: `internal/packets/handler.go` reads `packetId` from the frame header and looks up handlers in `packets.PacketDecisionFn`.
+- Missing handler behavior:
+  - Logs `Handler/Missing` for `CS_<id>`.
+  - Captures the raw, headerless payload via `debug.InsertPacket(packetId, &headerlessBuffer)`.
+  - Does not send a response packet.
+
+Payload capture is implemented in `internal/debug/insert_packet.go` and persists to `orm.Debug` when the DB is initialized (`orm.GormDB != nil`).
+
+### SC_12042 (outbound)
+
+- Protobuf type: `internal/protobuf/SC_12042.pb.go`.
+- Message shape:
+
+```go
+type SC_12042 struct {
+    ShipList []*SHIPINFO `protobuf:"bytes,1,rep,name=ship_list,json=shipList"`
+}
+```
+
+- `SHIPINFO` is a full ship record (`internal/protobuf/SHIPINFO.pb.go`). Key fields include `id`, `template_id`, `level`, `exp`, `energy`, `state`, `is_locked`, `intimacy`, `proficiency`, `create_time`, `skin_id`, `propose`, `max_level`, `activity_npc`, plus repeated/nested fields like `equip_info_list`, `transform_list`, `skill_id_list`, and `strength_list`.
+- Server usage: there are no references constructing/sending `protobuf.SC_12042` outside the generated file (search for `SC_12042{` only matches the generated code).
+
+## Wire encoding / decoding references
+
+- Frame parsing helpers: `internal/packets/magic.go` (`GetPacketSize`, `GetPacketId`, `GetPacketIndex`).
+- Dispatcher: `internal/packets/handler.go` (`Dispatch`). Called from `internal/entrypoint/entrypoint.go` via `connection.NewServer(..., packets.Dispatch)`.
+- Outbound protobuf encoding: `internal/connection/server.go` (`SendProtoMessage`, `GeneratePacketHeader`, `InjectPacketHeader`). Most handlers send responses through `client.SendMessage(...)` (`internal/connection/client.go`).
+
+## Notes / risks
+
+If a client sends `CS_12042` expecting an immediate response, the current behavior is "missing handler" + payload capture only, which may stall client flow until a real handler exists.


### PR DESCRIPTION
# Summary
- Document current behavior for packet id 12042: inbound handler is not registered, while an outbound protobuf type exists.
- Point to the exact dispatch/registry and wire encoding/decoding codepaths used by the server.
- Call out the operational risk of clients waiting on an unimplemented response.

# Changes
- Add `specs/SC_12042.md` describing CS_12042 missing-handler logging + payload capture, SC_12042 schema shape, and relevant code references.
