### PR TITLE
fix: return zero billboard rank without commander

### DIFF
--- a/internal/answer/billboard_rank_list.go
+++ b/internal/answer/billboard_rank_list.go
@@ -51,6 +51,10 @@ func BillboardMyRank(buffer *[]byte, client *connection.Client) (int, int, error
 		response := protobuf.SC_18204{Point: proto.Uint32(0), Rank: proto.Uint32(0)}
 		return client.SendMessage(18204, &response)
 	}
+	if client.Commander == nil {
+		response := protobuf.SC_18204{Point: proto.Uint32(0), Rank: proto.Uint32(0)}
+		return client.SendMessage(18204, &response)
+	}
 
 	response := protobuf.SC_18204{Point: proto.Uint32(billboardRankPoint), Rank: proto.Uint32(billboardRankRank)}
 	return client.SendMessage(18204, &response)

--- a/internal/answer/billboard_rank_list_test.go
+++ b/internal/answer/billboard_rank_list_test.go
@@ -147,3 +147,20 @@ func TestBillboardRankListPageNilCommanderReturnsEmpty(t *testing.T) {
 		t.Fatalf("expected empty list")
 	}
 }
+
+func TestBillboardMyRankNilCommanderReturnsZero(t *testing.T) {
+	client := &connection.Client{}
+	payload := &protobuf.CS_18203{Type: proto.Uint32(1)}
+	buf, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if _, _, err := BillboardMyRank(&buf, client); err != nil {
+		t.Fatalf("BillboardMyRank failed: %v", err)
+	}
+	var response protobuf.SC_18204
+	decodeRegisterResponse(t, client, 18204, &response)
+	if response.GetRank() != 0 || response.GetPoint() != 0 {
+		t.Fatalf("expected rank=0 and point=0")
+	}
+}


### PR DESCRIPTION
# Summary
- Avoids returning a non-zero "my rank" response before a commander is loaded.
- Keeps billboard rank packets responsive even for edge-case session states.

# Changes
- Return `rank=0` / `point=0` for `SC_18204` when the client has no commander attached.
- Add regression coverage for the nil-commander `CS_18203` path.
