### PR TITLE
feat: upgrade equipped ship equipment

### DIFF
--- a/internal/answer/upgrade_equipment_on_ship_14002.go
+++ b/internal/answer/upgrade_equipment_on_ship_14002.go
@@ -1,0 +1,108 @@
+package answer
+
+import (
+	"errors"
+
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+	"gorm.io/gorm"
+)
+
+const (
+	upgradeEquipmentOnShipResultOK             uint32 = 0
+	upgradeEquipmentOnShipResultGenericFailure uint32 = 1
+)
+
+func UpgradeEquipmentOnShip14002(buffer *[]byte, client *connection.Client) (int, int, error) {
+	response := protobuf.SC_14003{Result: proto.Uint32(upgradeEquipmentOnShipResultGenericFailure)}
+
+	if client == nil {
+		return 0, 14002, errors.New("nil client")
+	}
+	if client.Commander == nil {
+		return client.SendMessage(14003, &response)
+	}
+
+	var payload protobuf.CS_14002
+	if err := proto.Unmarshal(*buffer, &payload); err != nil {
+		return client.SendMessage(14003, &response)
+	}
+
+	shipID := payload.GetShipId()
+	pos := payload.GetPos()
+	lv := payload.GetLv()
+	if shipID == 0 || pos == 0 || lv == 0 {
+		return client.SendMessage(14003, &response)
+	}
+
+	if client.Commander.OwnedShipsMap == nil || client.Commander.OwnedResourcesMap == nil || client.Commander.CommanderItemsMap == nil || client.Commander.MiscItemsMap == nil {
+		if err := client.Commander.Load(); err != nil {
+			return client.SendMessage(14003, &response)
+		}
+	}
+
+	ship, ok := client.Commander.OwnedShipsMap[shipID]
+	if !ok {
+		return client.SendMessage(14003, &response)
+	}
+
+	current, err := orm.GetOwnedShipEquipment(orm.GormDB, client.Commander.CommanderID, ship.ID, pos)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			current = buildShipEquipmentFromMemory(client.Commander.CommanderID, ship, pos)
+		} else {
+			return 0, 14002, err
+		}
+	}
+	if current.EquipID == 0 {
+		return client.SendMessage(14003, &response)
+	}
+
+	upgradedID, itemCosts, coinCost, ok := computeEquipmentUpgradeCosts(current.EquipID, lv)
+	if !ok {
+		return client.SendMessage(14003, &response)
+	}
+	if coinCost != 0 && !client.Commander.HasEnoughResource(1, coinCost) {
+		return client.SendMessage(14003, &response)
+	}
+	for itemID, count := range itemCosts {
+		if !client.Commander.HasEnoughItem(itemID, count) {
+			return client.SendMessage(14003, &response)
+		}
+	}
+
+	tx := orm.GormDB.Begin()
+	if tx.Error != nil {
+		return client.SendMessage(14003, &response)
+	}
+	if coinCost != 0 {
+		if err := client.Commander.ConsumeResourceTx(tx, 1, coinCost); err != nil {
+			tx.Rollback()
+			return client.SendMessage(14003, &response)
+		}
+	}
+	for itemID, count := range itemCosts {
+		if count == 0 {
+			continue
+		}
+		if err := client.Commander.ConsumeItemTx(tx, itemID, count); err != nil {
+			tx.Rollback()
+			return client.SendMessage(14003, &response)
+		}
+	}
+
+	current.EquipID = upgradedID
+	if err := orm.UpsertOwnedShipEquipmentTx(tx, current); err != nil {
+		tx.Rollback()
+		return client.SendMessage(14003, &response)
+	}
+	if err := tx.Commit().Error; err != nil {
+		return client.SendMessage(14003, &response)
+	}
+
+	applyShipEquipmentUpdate(ship, current)
+	response.Result = proto.Uint32(upgradeEquipmentOnShipResultOK)
+	return client.SendMessage(14003, &response)
+}

--- a/internal/answer/upgrade_equipment_on_ship_14002_test.go
+++ b/internal/answer/upgrade_equipment_on_ship_14002_test.go
@@ -1,0 +1,316 @@
+package answer_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/answer"
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func setupUpgradeEquipmentOnShip14002Test(t *testing.T, commanderID uint32) *connection.Client {
+	t.Helper()
+
+	os.Setenv("MODE", "test")
+	orm.InitDatabase()
+	clearEquipTable(t, &orm.OwnedShipEquipment{})
+	clearEquipTable(t, &orm.OwnedShip{})
+	clearEquipTable(t, &orm.OwnedResource{})
+	clearEquipTable(t, &orm.CommanderItem{})
+	clearEquipTable(t, &orm.CommanderMiscItem{})
+	clearEquipTable(t, &orm.Equipment{})
+	clearEquipTable(t, &orm.Ship{})
+	clearEquipTable(t, &orm.Commander{})
+
+	commander := orm.Commander{CommanderID: commanderID, AccountID: commanderID, Name: "Upgrade Equip Ship"}
+	if err := orm.GormDB.Create(&commander).Error; err != nil {
+		t.Fatalf("create commander: %v", err)
+	}
+	return &connection.Client{Commander: &commander}
+}
+
+func TestUpgradeEquipmentOnShip14002SuccessUpdatesSlotAndChargesCosts(t *testing.T) {
+	client := setupUpgradeEquipmentOnShip14002Test(t, 9014002)
+
+	shipTemplate := orm.Ship{TemplateID: 1001, Name: "Ship", EnglishName: "Ship", RarityID: 2, Star: 1, Type: 1, Nationality: 1, BuildTime: 10}
+	if err := orm.GormDB.Create(&shipTemplate).Error; err != nil {
+		t.Fatalf("create ship: %v", err)
+	}
+	ownedShip := orm.OwnedShip{OwnerID: client.Commander.CommanderID, ShipID: 1001, ID: 50001, Level: 1, MaxLevel: 50}
+	if err := orm.GormDB.Create(&ownedShip).Error; err != nil {
+		t.Fatalf("create owned ship: %v", err)
+	}
+
+	if err := orm.GormDB.Create(&orm.OwnedResource{CommanderID: client.Commander.CommanderID, ResourceID: 1, Amount: 100}).Error; err != nil {
+		t.Fatalf("create gold resource: %v", err)
+	}
+	if err := orm.GormDB.Create(&orm.CommanderItem{CommanderID: client.Commander.CommanderID, ItemID: 200, Count: 3}).Error; err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+
+	baseID := uint32(995000)
+	upgradedID := uint32(995001)
+	createTestEquipment(t, baseID, upgradedID, 10, json.RawMessage(`[[200,1]]`))
+	createTestEquipment(t, upgradedID, 0, 0, nil)
+
+	if err := orm.GormDB.Create(&orm.OwnedShipEquipment{OwnerID: client.Commander.CommanderID, ShipID: ownedShip.ID, Pos: 1, EquipID: baseID, SkinID: 123}).Error; err != nil {
+		t.Fatalf("create ship equipment: %v", err)
+	}
+
+	payload := &protobuf.CS_14002{ShipId: proto.Uint32(ownedShip.ID), Pos: proto.Uint32(1), Lv: proto.Uint32(1)}
+	buf, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	client.Buffer.Reset()
+	if _, _, err := answer.UpgradeEquipmentOnShip14002(&buf, client); err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+
+	resp := &protobuf.SC_14003{}
+	decodePacket(t, client, 14003, resp)
+	if resp.GetResult() != 0 {
+		t.Fatalf("expected result 0, got %d", resp.GetResult())
+	}
+
+	var updated orm.OwnedShipEquipment
+	if err := orm.GormDB.Where("owner_id = ? AND ship_id = ? AND pos = ?", client.Commander.CommanderID, ownedShip.ID, 1).First(&updated).Error; err != nil {
+		t.Fatalf("load ship equipment: %v", err)
+	}
+	if updated.EquipID != upgradedID {
+		t.Fatalf("expected equip id %d, got %d", upgradedID, updated.EquipID)
+	}
+	if updated.SkinID != 123 {
+		t.Fatalf("expected skin id 123 to remain, got %d", updated.SkinID)
+	}
+
+	var gold orm.OwnedResource
+	if err := orm.GormDB.Where("commander_id = ? AND resource_id = ?", client.Commander.CommanderID, 1).First(&gold).Error; err != nil {
+		t.Fatalf("load gold: %v", err)
+	}
+	if gold.Amount != 90 {
+		t.Fatalf("expected gold 90, got %d", gold.Amount)
+	}
+
+	var item orm.CommanderItem
+	if err := orm.GormDB.Where("commander_id = ? AND item_id = ?", client.Commander.CommanderID, 200).First(&item).Error; err != nil {
+		t.Fatalf("load item: %v", err)
+	}
+	if item.Count != 2 {
+		t.Fatalf("expected item count 2, got %d", item.Count)
+	}
+}
+
+func TestUpgradeEquipmentOnShip14002ShipIDZero(t *testing.T) {
+	client := &connection.Client{Commander: &orm.Commander{CommanderID: 9014010, AccountID: 9014010, Name: "shipid-zero"}}
+
+	payload := &protobuf.CS_14002{ShipId: proto.Uint32(0), Pos: proto.Uint32(1), Lv: proto.Uint32(1)}
+	buf, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if _, _, err := answer.UpgradeEquipmentOnShip14002(&buf, client); err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+
+	resp := &protobuf.SC_14003{}
+	decodePacket(t, client, 14003, resp)
+	if resp.GetResult() == 0 {
+		t.Fatalf("expected non-zero result")
+	}
+}
+
+func TestUpgradeEquipmentOnShip14002PosZero(t *testing.T) {
+	client := &connection.Client{Commander: &orm.Commander{CommanderID: 9014011, AccountID: 9014011, Name: "pos-zero"}}
+
+	payload := &protobuf.CS_14002{ShipId: proto.Uint32(1), Pos: proto.Uint32(0), Lv: proto.Uint32(1)}
+	buf, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if _, _, err := answer.UpgradeEquipmentOnShip14002(&buf, client); err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+
+	resp := &protobuf.SC_14003{}
+	decodePacket(t, client, 14003, resp)
+	if resp.GetResult() == 0 {
+		t.Fatalf("expected non-zero result")
+	}
+}
+
+func TestUpgradeEquipmentOnShip14002LvZero(t *testing.T) {
+	client := &connection.Client{Commander: &orm.Commander{CommanderID: 9014012, AccountID: 9014012, Name: "lv-zero"}}
+
+	payload := &protobuf.CS_14002{ShipId: proto.Uint32(1), Pos: proto.Uint32(1), Lv: proto.Uint32(0)}
+	buf, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if _, _, err := answer.UpgradeEquipmentOnShip14002(&buf, client); err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+
+	resp := &protobuf.SC_14003{}
+	decodePacket(t, client, 14003, resp)
+	if resp.GetResult() == 0 {
+		t.Fatalf("expected non-zero result")
+	}
+}
+
+func TestUpgradeEquipmentOnShip14002NonOwnedShipFails(t *testing.T) {
+	client := setupUpgradeEquipmentOnShip14002Test(t, 9014003)
+
+	payload := &protobuf.CS_14002{ShipId: proto.Uint32(99999), Pos: proto.Uint32(1), Lv: proto.Uint32(1)}
+	buf, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	client.Buffer.Reset()
+	if _, _, err := answer.UpgradeEquipmentOnShip14002(&buf, client); err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+
+	resp := &protobuf.SC_14003{}
+	decodePacket(t, client, 14003, resp)
+	if resp.GetResult() == 0 {
+		t.Fatalf("expected non-zero result")
+	}
+}
+
+func TestUpgradeEquipmentOnShip14002EmptySlotFails(t *testing.T) {
+	client := setupUpgradeEquipmentOnShip14002Test(t, 9014004)
+
+	shipTemplate := orm.Ship{TemplateID: 1001, Name: "Ship", EnglishName: "Ship", RarityID: 2, Star: 1, Type: 1, Nationality: 1, BuildTime: 10}
+	if err := orm.GormDB.Create(&shipTemplate).Error; err != nil {
+		t.Fatalf("create ship: %v", err)
+	}
+	ownedShip := orm.OwnedShip{OwnerID: client.Commander.CommanderID, ShipID: 1001, ID: 50002, Level: 1, MaxLevel: 50}
+	if err := orm.GormDB.Create(&ownedShip).Error; err != nil {
+		t.Fatalf("create owned ship: %v", err)
+	}
+
+	payload := &protobuf.CS_14002{ShipId: proto.Uint32(ownedShip.ID), Pos: proto.Uint32(1), Lv: proto.Uint32(1)}
+	buf, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	client.Buffer.Reset()
+	if _, _, err := answer.UpgradeEquipmentOnShip14002(&buf, client); err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+
+	resp := &protobuf.SC_14003{}
+	decodePacket(t, client, 14003, resp)
+	if resp.GetResult() == 0 {
+		t.Fatalf("expected non-zero result")
+	}
+}
+
+func TestUpgradeEquipmentOnShip14002NotEnoughGoldDoesNotMutate(t *testing.T) {
+	client := setupUpgradeEquipmentOnShip14002Test(t, 9014005)
+
+	shipTemplate := orm.Ship{TemplateID: 1001, Name: "Ship", EnglishName: "Ship", RarityID: 2, Star: 1, Type: 1, Nationality: 1, BuildTime: 10}
+	if err := orm.GormDB.Create(&shipTemplate).Error; err != nil {
+		t.Fatalf("create ship: %v", err)
+	}
+	ownedShip := orm.OwnedShip{OwnerID: client.Commander.CommanderID, ShipID: 1001, ID: 50003, Level: 1, MaxLevel: 50}
+	if err := orm.GormDB.Create(&ownedShip).Error; err != nil {
+		t.Fatalf("create owned ship: %v", err)
+	}
+
+	if err := orm.GormDB.Create(&orm.OwnedResource{CommanderID: client.Commander.CommanderID, ResourceID: 1, Amount: 5}).Error; err != nil {
+		t.Fatalf("create gold: %v", err)
+	}
+	if err := orm.GormDB.Create(&orm.CommanderItem{CommanderID: client.Commander.CommanderID, ItemID: 200, Count: 3}).Error; err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+
+	baseID := uint32(996000)
+	upgradedID := uint32(996001)
+	createTestEquipment(t, baseID, upgradedID, 10, json.RawMessage(`[[200,1]]`))
+	createTestEquipment(t, upgradedID, 0, 0, nil)
+	if err := orm.GormDB.Create(&orm.OwnedShipEquipment{OwnerID: client.Commander.CommanderID, ShipID: ownedShip.ID, Pos: 1, EquipID: baseID, SkinID: 0}).Error; err != nil {
+		t.Fatalf("create ship equipment: %v", err)
+	}
+
+	payload := &protobuf.CS_14002{ShipId: proto.Uint32(ownedShip.ID), Pos: proto.Uint32(1), Lv: proto.Uint32(1)}
+	buf, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	client.Buffer.Reset()
+	if _, _, err := answer.UpgradeEquipmentOnShip14002(&buf, client); err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+
+	resp := &protobuf.SC_14003{}
+	decodePacket(t, client, 14003, resp)
+	if resp.GetResult() == 0 {
+		t.Fatalf("expected non-zero result")
+	}
+
+	var entry orm.OwnedShipEquipment
+	if err := orm.GormDB.Where("owner_id = ? AND ship_id = ? AND pos = ?", client.Commander.CommanderID, ownedShip.ID, 1).First(&entry).Error; err != nil {
+		t.Fatalf("load ship equipment: %v", err)
+	}
+	if entry.EquipID != baseID {
+		t.Fatalf("expected equip id %d, got %d", baseID, entry.EquipID)
+	}
+}
+
+func TestUpgradeEquipmentOnShip14002NotEnoughItemsDoesNotMutate(t *testing.T) {
+	client := setupUpgradeEquipmentOnShip14002Test(t, 9014006)
+
+	shipTemplate := orm.Ship{TemplateID: 1001, Name: "Ship", EnglishName: "Ship", RarityID: 2, Star: 1, Type: 1, Nationality: 1, BuildTime: 10}
+	if err := orm.GormDB.Create(&shipTemplate).Error; err != nil {
+		t.Fatalf("create ship: %v", err)
+	}
+	ownedShip := orm.OwnedShip{OwnerID: client.Commander.CommanderID, ShipID: 1001, ID: 50004, Level: 1, MaxLevel: 50}
+	if err := orm.GormDB.Create(&ownedShip).Error; err != nil {
+		t.Fatalf("create owned ship: %v", err)
+	}
+
+	if err := orm.GormDB.Create(&orm.OwnedResource{CommanderID: client.Commander.CommanderID, ResourceID: 1, Amount: 100}).Error; err != nil {
+		t.Fatalf("create gold: %v", err)
+	}
+	if err := orm.GormDB.Create(&orm.CommanderItem{CommanderID: client.Commander.CommanderID, ItemID: 200, Count: 0}).Error; err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+
+	baseID := uint32(997000)
+	upgradedID := uint32(997001)
+	createTestEquipment(t, baseID, upgradedID, 10, json.RawMessage(`[[200,1]]`))
+	createTestEquipment(t, upgradedID, 0, 0, nil)
+	if err := orm.GormDB.Create(&orm.OwnedShipEquipment{OwnerID: client.Commander.CommanderID, ShipID: ownedShip.ID, Pos: 1, EquipID: baseID, SkinID: 0}).Error; err != nil {
+		t.Fatalf("create ship equipment: %v", err)
+	}
+
+	payload := &protobuf.CS_14002{ShipId: proto.Uint32(ownedShip.ID), Pos: proto.Uint32(1), Lv: proto.Uint32(1)}
+	buf, err := proto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	client.Buffer.Reset()
+	if _, _, err := answer.UpgradeEquipmentOnShip14002(&buf, client); err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+
+	resp := &protobuf.SC_14003{}
+	decodePacket(t, client, 14003, resp)
+	if resp.GetResult() == 0 {
+		t.Fatalf("expected non-zero result")
+	}
+
+	var entry orm.OwnedShipEquipment
+	if err := orm.GormDB.Where("owner_id = ? AND ship_id = ? AND pos = ?", client.Commander.CommanderID, ownedShip.ID, 1).First(&entry).Error; err != nil {
+		t.Fatalf("load ship equipment: %v", err)
+	}
+	if entry.EquipID != baseID {
+		t.Fatalf("expected equip id %d, got %d", baseID, entry.EquipID)
+	}
+}

--- a/internal/entrypoint/packet_registry.go
+++ b/internal/entrypoint/packet_registry.go
@@ -248,6 +248,7 @@ func registerPackets() {
 	packets.RegisterPacketHandler(12208, []packets.PacketHandler{answer.ChangeRandomFlagShips})
 	packets.RegisterPacketHandler(12210, []packets.PacketHandler{answer.FinishPhantomQuest})
 	packets.RegisterPacketHandler(12212, []packets.PacketHandler{answer.GetPhantomQuestProgress})
+	packets.RegisterPacketHandler(14002, []packets.PacketHandler{answer.UpgradeEquipmentOnShip14002})
 	packets.RegisterPacketHandler(14006, []packets.PacketHandler{answer.CompositeEquipment})
 	packets.RegisterPacketHandler(14004, []packets.PacketHandler{answer.UpgradeEquipmentInBag14004})
 	packets.RegisterPacketHandler(14008, []packets.PacketHandler{answer.DestroyEquipments})

--- a/specs/CS_14002.md
+++ b/specs/CS_14002.md
@@ -1,0 +1,23 @@
+# CS_14002
+
+Upgrade equipment currently equipped on a ship.
+
+## Request
+
+`CS_14002 { ship_id, pos, lv }`
+
+- `ship_id`: owned ship id (not template id)
+- `pos`: 1-based equipment slot index
+- `lv`: delta upgrade steps (targetLevel - currentLevel)
+
+## Response
+
+`SC_14003 { result }`
+
+- `result == 0`: success
+- `result != 0`: failure (no state changes persisted)
+
+## Notes
+
+- Upgrade costs/chain follow the same walk as bag upgrades (`CS_14004`): iterate `orm.Equipment.Next` for `lv` steps, consume `TransUseGold` and `TransUseItem` at each step.
+- On success, server updates the ship slot's `equip_id` to the upgraded template id and preserves `skin_id`.


### PR DESCRIPTION
# Summary
- handle upgrading equipment directly in ship slots, consuming gold/materials transactionally
- validate ship ownership, slot presence, and upgrade chain

# Changes
- register the 14002 handler in the packet registry
- add handler implementation that updates `OwnedShipEquipment.equip_id` while preserving `skin_id`
- add unit tests for success and failure cases
- document packet notes in `specs/CS_14002.md`
