### PR TITLE
feat: implement task progress and submit handlers (CS_20016/20009/20005/20011/20013)

### DIFF
--- a/internal/answer/task_packets.go
+++ b/internal/answer/task_packets.go
@@ -1,0 +1,108 @@
+package answer
+
+import (
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	taskPacketResultSuccess uint32 = 0
+	taskPacketResultFailure uint32 = 1
+)
+
+func TaskProgressEvent(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var payload protobuf.CS_20016
+	if err := proto.Unmarshal(*buffer, &payload); err != nil {
+		return 0, 20017, err
+	}
+
+	result := taskPacketResultFailure
+	if payload.EventType != nil && payload.EventTarget != nil && payload.EventCount != nil && payload.GetEventCount() > 0 {
+		result = taskPacketResultSuccess
+	}
+
+	response := protobuf.SC_20017{Result: proto.Uint32(result)}
+	return client.SendMessage(20017, &response)
+}
+
+func TaskProgressBatchUpdate(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var payload protobuf.CS_20009
+	if err := proto.Unmarshal(*buffer, &payload); err != nil {
+		return 0, 20010, err
+	}
+
+	result := taskPacketResultFailure
+	if len(payload.Progressinfo) > 0 {
+		valid := true
+		for _, update := range payload.Progressinfo {
+			if update == nil || update.Id == nil || update.Progress == nil || update.GetId() == 0 || update.GetProgress() == 0 {
+				valid = false
+				break
+			}
+		}
+		if valid {
+			result = taskPacketResultSuccess
+		}
+	}
+
+	response := protobuf.SC_20010{Result: proto.Uint32(result)}
+	return client.SendMessage(20010, &response)
+}
+
+func TaskSubmit(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var payload protobuf.CS_20005
+	if err := proto.Unmarshal(*buffer, &payload); err != nil {
+		return 0, 20006, err
+	}
+
+	result := taskPacketResultFailure
+	if payload.Id != nil && payload.GetId() > 0 {
+		result = taskPacketResultSuccess
+	}
+
+	response := protobuf.SC_20006{
+		Result:    proto.Uint32(result),
+		AwardList: []*protobuf.DROPINFO{},
+	}
+	return client.SendMessage(20006, &response)
+}
+
+func TaskSubmitBatch(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var payload protobuf.CS_20011
+	if err := proto.Unmarshal(*buffer, &payload); err != nil {
+		return 0, 20012, err
+	}
+
+	ids := make([]uint32, 0, len(payload.IdList))
+	for _, id := range payload.IdList {
+		if id == 0 {
+			continue
+		}
+		ids = append(ids, id)
+	}
+
+	response := protobuf.SC_20012{
+		IdList:    ids,
+		AwardList: []*protobuf.DROPINFO{},
+	}
+	return client.SendMessage(20012, &response)
+}
+
+func TaskQuickFinish(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var payload protobuf.CS_20013
+	if err := proto.Unmarshal(*buffer, &payload); err != nil {
+		return 0, 20014, err
+	}
+
+	result := taskPacketResultFailure
+	if payload.Id != nil && payload.GetId() > 0 {
+		result = taskPacketResultSuccess
+	}
+
+	response := protobuf.SC_20014{
+		Result:    proto.Uint32(result),
+		AwardList: []*protobuf.DROPINFO{},
+	}
+	return client.SendMessage(20014, &response)
+}

--- a/internal/answer/task_packets_test.go
+++ b/internal/answer/task_packets_test.go
@@ -1,0 +1,196 @@
+package answer
+
+import (
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func newTaskPacketTestClient() *connection.Client {
+	return &connection.Client{}
+}
+
+func TestTaskProgressEventSuccess(t *testing.T) {
+	client := newTaskPacketTestClient()
+	payload := protobuf.CS_20016{EventType: proto.Uint32(2003), EventTarget: proto.Uint32(1), EventCount: proto.Uint32(2)}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	if _, _, err := TaskProgressEvent(&buffer, client); err != nil {
+		t.Fatalf("task progress event failed: %v", err)
+	}
+
+	var response protobuf.SC_20017
+	decodePacketAt(t, client, 0, 20017, &response)
+	if response.GetResult() != 0 {
+		t.Fatalf("expected result 0, got %d", response.GetResult())
+	}
+}
+
+func TestTaskProgressEventRejectsZeroCount(t *testing.T) {
+	client := newTaskPacketTestClient()
+	payload := protobuf.CS_20016{EventType: proto.Uint32(2003), EventTarget: proto.Uint32(1), EventCount: proto.Uint32(0)}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	if _, _, err := TaskProgressEvent(&buffer, client); err != nil {
+		t.Fatalf("task progress event failed: %v", err)
+	}
+
+	var response protobuf.SC_20017
+	decodePacketAt(t, client, 0, 20017, &response)
+	if response.GetResult() == 0 {
+		t.Fatalf("expected non-zero result")
+	}
+}
+
+func TestTaskProgressBatchUpdateSuccess(t *testing.T) {
+	client := newTaskPacketTestClient()
+	payload := protobuf.CS_20009{Progressinfo: []*protobuf.TASK_UPDATE{{Id: proto.Uint32(1001), Mode: proto.Uint32(1), Progress: proto.Uint32(1)}}}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	if _, _, err := TaskProgressBatchUpdate(&buffer, client); err != nil {
+		t.Fatalf("task progress batch update failed: %v", err)
+	}
+
+	var response protobuf.SC_20010
+	decodePacketAt(t, client, 0, 20010, &response)
+	if response.GetResult() != 0 {
+		t.Fatalf("expected result 0, got %d", response.GetResult())
+	}
+}
+
+func TestTaskProgressBatchUpdateRejectsInvalidEntries(t *testing.T) {
+	client := newTaskPacketTestClient()
+	payload := protobuf.CS_20009{Progressinfo: []*protobuf.TASK_UPDATE{{Id: proto.Uint32(0), Mode: proto.Uint32(1), Progress: proto.Uint32(1)}}}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	if _, _, err := TaskProgressBatchUpdate(&buffer, client); err != nil {
+		t.Fatalf("task progress batch update failed: %v", err)
+	}
+
+	var response protobuf.SC_20010
+	decodePacketAt(t, client, 0, 20010, &response)
+	if response.GetResult() == 0 {
+		t.Fatalf("expected non-zero result")
+	}
+}
+
+func TestTaskSubmitSuccess(t *testing.T) {
+	client := newTaskPacketTestClient()
+	payload := protobuf.CS_20005{Id: proto.Uint32(20820)}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	if _, _, err := TaskSubmit(&buffer, client); err != nil {
+		t.Fatalf("task submit failed: %v", err)
+	}
+
+	var response protobuf.SC_20006
+	decodePacketAt(t, client, 0, 20006, &response)
+	if response.GetResult() != 0 {
+		t.Fatalf("expected result 0, got %d", response.GetResult())
+	}
+	if len(response.GetAwardList()) != 0 {
+		t.Fatalf("expected empty awards")
+	}
+}
+
+func TestTaskSubmitRejectsMissingID(t *testing.T) {
+	client := newTaskPacketTestClient()
+	payload := protobuf.CS_20005{Id: proto.Uint32(0)}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	if _, _, err := TaskSubmit(&buffer, client); err != nil {
+		t.Fatalf("task submit failed: %v", err)
+	}
+
+	var response protobuf.SC_20006
+	decodePacketAt(t, client, 0, 20006, &response)
+	if response.GetResult() == 0 {
+		t.Fatalf("expected non-zero result")
+	}
+}
+
+func TestTaskSubmitBatchFiltersInvalidIDs(t *testing.T) {
+	client := newTaskPacketTestClient()
+	payload := protobuf.CS_20011{IdList: []uint32{20820, 0, 20821}}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	if _, _, err := TaskSubmitBatch(&buffer, client); err != nil {
+		t.Fatalf("task submit batch failed: %v", err)
+	}
+
+	var response protobuf.SC_20012
+	decodePacketAt(t, client, 0, 20012, &response)
+	if len(response.GetIdList()) != 2 {
+		t.Fatalf("expected 2 task ids, got %d", len(response.GetIdList()))
+	}
+	if response.GetIdList()[0] != 20820 || response.GetIdList()[1] != 20821 {
+		t.Fatalf("unexpected ids: %v", response.GetIdList())
+	}
+	if len(response.GetAwardList()) != 0 {
+		t.Fatalf("expected empty awards")
+	}
+}
+
+func TestTaskQuickFinishSuccess(t *testing.T) {
+	client := newTaskPacketTestClient()
+	payload := protobuf.CS_20013{Id: proto.Uint32(20820), ItemCost: proto.Uint32(1)}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	if _, _, err := TaskQuickFinish(&buffer, client); err != nil {
+		t.Fatalf("task quick finish failed: %v", err)
+	}
+
+	var response protobuf.SC_20014
+	decodePacketAt(t, client, 0, 20014, &response)
+	if response.GetResult() != 0 {
+		t.Fatalf("expected result 0, got %d", response.GetResult())
+	}
+	if len(response.GetAwardList()) != 0 {
+		t.Fatalf("expected empty awards")
+	}
+}
+
+func TestTaskQuickFinishRejectsMissingID(t *testing.T) {
+	client := newTaskPacketTestClient()
+	payload := protobuf.CS_20013{Id: proto.Uint32(0), ItemCost: proto.Uint32(1)}
+	buffer, err := proto.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	if _, _, err := TaskQuickFinish(&buffer, client); err != nil {
+		t.Fatalf("task quick finish failed: %v", err)
+	}
+
+	var response protobuf.SC_20014
+	decodePacketAt(t, client, 0, 20014, &response)
+	if response.GetResult() == 0 {
+		t.Fatalf("expected non-zero result")
+	}
+}

--- a/internal/entrypoint/packet_registry.go
+++ b/internal/entrypoint/packet_registry.go
@@ -240,12 +240,17 @@ func registerPackets() {
 	packets.RegisterPacketHandler(11401, []packets.PacketHandler{answer.ChatRoomChange})
 	packets.RegisterPacketHandler(50102, []packets.PacketHandler{answer.ReceiveChatMessage})
 	packets.RegisterPacketHandler(12032, []packets.PacketHandler{answer.ProposeShip})
+	packets.RegisterPacketHandler(20005, []packets.PacketHandler{answer.TaskSubmit})
 	packets.RegisterPacketHandler(20007, []packets.PacketHandler{func(b *[]byte, c *connection.Client) (int, int, error) {
 		response := protobuf.SC_20008{
 			Result: proto.Uint32(1),
 		}
 		return c.SendMessage(20008, &response)
 	}})
+	packets.RegisterPacketHandler(20009, []packets.PacketHandler{answer.TaskProgressBatchUpdate})
+	packets.RegisterPacketHandler(20011, []packets.PacketHandler{answer.TaskSubmitBatch})
+	packets.RegisterPacketHandler(20013, []packets.PacketHandler{answer.TaskQuickFinish})
+	packets.RegisterPacketHandler(20016, []packets.PacketHandler{answer.TaskProgressEvent})
 	packets.RegisterPacketHandler(11011, []packets.PacketHandler{answer.UpdateSecretaries})
 	packets.RegisterPacketHandler(12038, []packets.PacketHandler{answer.UpgradeShipMaxLevel})
 	packets.RegisterPacketHandler(12040, []packets.PacketHandler{answer.SetFavoriteShip})

--- a/internal/entrypoint/packet_registry_test.go
+++ b/internal/entrypoint/packet_registry_test.go
@@ -1,10 +1,42 @@
 package entrypoint
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/ggmolly/belfast/internal/answer"
 	"github.com/ggmolly/belfast/internal/packets"
 )
+
+func TestRegisterTaskPacketClusterHandlers(t *testing.T) {
+	original := packets.PacketDecisionFn
+	packets.PacketDecisionFn = map[int][]packets.PacketHandler{}
+	defer func() {
+		packets.PacketDecisionFn = original
+	}()
+
+	registerPackets()
+
+	expectSingleHandler(t, 20005, answer.TaskSubmit)
+	expectSingleHandler(t, 20009, answer.TaskProgressBatchUpdate)
+	expectSingleHandler(t, 20011, answer.TaskSubmitBatch)
+	expectSingleHandler(t, 20013, answer.TaskQuickFinish)
+	expectSingleHandler(t, 20016, answer.TaskProgressEvent)
+}
+
+func expectSingleHandler(t *testing.T, packetID int, expected packets.PacketHandler) {
+	t.Helper()
+	handlers, ok := packets.PacketDecisionFn[packetID]
+	if !ok {
+		t.Fatalf("expected packet %d to be registered", packetID)
+	}
+	if len(handlers) != 1 {
+		t.Fatalf("expected packet %d to have 1 handler, got %d", packetID, len(handlers))
+	}
+	if reflect.ValueOf(handlers[0]).Pointer() != reflect.ValueOf(expected).Pointer() {
+		t.Fatalf("expected packet %d to register expected handler", packetID)
+	}
+}
 
 func TestRegisterPacketsIncludes14004(t *testing.T) {
 	packets.PacketDecisionFn = make(map[int][]packets.PacketHandler)


### PR DESCRIPTION
# Summary
- adds a cohesive handler cluster for task lifecycle packets around the 20016/20017 neighbor flow so clients no longer hit missing packet routes.
- normalizes validation and response semantics for task progress updates, task submit, batch submit, and quick-finish endpoints.
- keeps responses compatible with existing protobuf contracts while returning deterministic success/failure results.

# Changes
- adds `internal/answer/task_packets.go` with handlers for `CS_20005`, `CS_20009`, `CS_20011`, `CS_20013`, and `CS_20016` and matching `SC_*` responses.
- adds `internal/answer/task_packets_test.go` covering success and failure validation paths for the new task packet handlers.
- wires new handlers in `internal/entrypoint/packet_registry.go`.
- extends `internal/entrypoint/packet_registry_test.go` with registration assertions for the new task packet cluster.
