### PR TITLE
test: cover batch friend profile lookup behavior

### DIFF
--- a/internal/answer/commander_friend_batch_get_test.go
+++ b/internal/answer/commander_friend_batch_get_test.go
@@ -1,0 +1,98 @@
+package answer
+
+import (
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestCommanderFriendBatchGetProfilesAndPresence(t *testing.T) {
+	client := setupHandlerCommander(t)
+	onlineProfile := seedSocialCommander(t, 911001, "Batch Online")
+	offlineProfile := seedSocialCommander(t, 911002, "Batch Offline")
+
+	onlineCommander := orm.Commander{CommanderID: onlineProfile.CommanderID}
+	if err := onlineCommander.Load(); err != nil {
+		t.Fatalf("load online commander: %v", err)
+	}
+	client.Server.AddClient(&connection.Client{Commander: &onlineCommander, Hash: onlineProfile.CommanderID})
+
+	request := &protobuf.CS_50018{UserIdList: []uint32{onlineProfile.CommanderID, 999999, offlineProfile.CommanderID}}
+	buffer, err := proto.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	if _, _, err := CommanderFriendBatchGet(&buffer, client); err != nil {
+		t.Fatalf("CommanderFriendBatchGet failed: %v", err)
+	}
+
+	response := &protobuf.SC_50019{}
+	decodePacketAt(t, client, 0, 50019, response)
+	if len(response.GetUserList()) != 2 {
+		t.Fatalf("expected 2 user profiles, got %d", len(response.GetUserList()))
+	}
+
+	first := response.GetUserList()[0]
+	if first.GetId() != onlineProfile.CommanderID {
+		t.Fatalf("expected first id %d, got %d", onlineProfile.CommanderID, first.GetId())
+	}
+	if first.GetName() != onlineProfile.Name || first.GetLv() != onlineProfile.Level || first.GetAdv() != onlineProfile.Manifesto {
+		t.Fatalf("unexpected first profile payload: %+v", first)
+	}
+	if first.GetOnline() != 1 || first.GetPreOnlineTime() != 0 {
+		t.Fatalf("expected online profile state, got online=%d pre_online_time=%d", first.GetOnline(), first.GetPreOnlineTime())
+	}
+	if first.GetDisplay() == nil {
+		t.Fatalf("expected display for online profile")
+	}
+	if first.GetDisplay().GetIcon() != onlineProfile.DisplayIconID ||
+		first.GetDisplay().GetSkin() != onlineProfile.DisplaySkinID ||
+		first.GetDisplay().GetIconFrame() != onlineProfile.SelectedIconFrameID ||
+		first.GetDisplay().GetChatFrame() != onlineProfile.SelectedChatFrameID ||
+		first.GetDisplay().GetIconTheme() != onlineProfile.DisplayIconThemeID {
+		t.Fatalf("unexpected online display payload: %+v", first.GetDisplay())
+	}
+
+	second := response.GetUserList()[1]
+	if second.GetId() != offlineProfile.CommanderID {
+		t.Fatalf("expected second id %d, got %d", offlineProfile.CommanderID, second.GetId())
+	}
+	if second.GetOnline() != 0 {
+		t.Fatalf("expected offline profile online=0, got %d", second.GetOnline())
+	}
+	if second.GetPreOnlineTime() == 0 || second.GetPreOnlineTime() != offlineProfile.LastLoginUnix {
+		t.Fatalf("expected offline pre_online_time=%d, got %d", offlineProfile.LastLoginUnix, second.GetPreOnlineTime())
+	}
+}
+
+func TestCommanderFriendBatchGetEmptyInput(t *testing.T) {
+	client := setupHandlerCommander(t)
+
+	request := &protobuf.CS_50018{UserIdList: nil}
+	buffer, err := proto.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	if _, _, err := CommanderFriendBatchGet(&buffer, client); err != nil {
+		t.Fatalf("CommanderFriendBatchGet failed: %v", err)
+	}
+
+	response := &protobuf.SC_50019{}
+	decodePacketAt(t, client, 0, 50019, response)
+	if len(response.GetUserList()) != 0 {
+		t.Fatalf("expected empty user list, got %d", len(response.GetUserList()))
+	}
+}
+
+func TestCommanderFriendBatchGetDecodeFailure(t *testing.T) {
+	client := setupHandlerCommander(t)
+	invalid := []byte{0xff, 0x00}
+	if _, outID, err := CommanderFriendBatchGet(&invalid, client); err == nil || outID != 50019 {
+		t.Fatalf("expected decode error with outgoing id 50019, got err=%v out=%d", err, outID)
+	}
+}

--- a/internal/orm/friend_profiles_test.go
+++ b/internal/orm/friend_profiles_test.go
@@ -68,6 +68,45 @@ VALUES ($1, $2, 10, 0, $3, $4, 0, 0, '1970-01-01 00:00:00+00', 0, 0, 0, 0, 0, 0,
 	}
 }
 
+func TestGetCommanderSocialProfilesByIDsFiltersMissingAndDeleted(t *testing.T) {
+	initCommanderItemTestDB(t)
+	clearTable(t, &Commander{})
+
+	seedCommander := func(id uint32, name string, deleted bool) {
+		t.Helper()
+		if _, err := db.DefaultStore.Pool.Exec(context.Background(), `
+INSERT INTO commanders (commander_id, account_id, level, exp, name, last_login, guide_index, new_guide_index, name_change_cooldown, room_id, exchange_count, draw_count1, draw_count10, support_requisition_count, support_requisition_month, collect_attack_count, acc_pay_lv, living_area_cover_id, selected_icon_frame_id, selected_chat_frame_id, selected_battle_ui_id, display_icon_id, display_skin_id, display_icon_theme_id, manifesto, dorm_name, random_ship_mode, random_flag_ship_enabled, deleted_at)
+VALUES ($1, $2, 10, 0, $3, $4, 0, 0, '1970-01-01 00:00:00+00', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, false, $5)
+`, int64(id), int64(id), name, time.Now().UTC(), nullableDeletedAt(deleted)); err != nil {
+			t.Fatalf("seed commander: %v", err)
+		}
+	}
+
+	seedCommander(7101, "BatchA", false)
+	seedCommander(7102, "BatchB", false)
+	seedCommander(7103, "BatchDeleted", true)
+
+	profiles, err := GetCommanderSocialProfilesByIDs([]uint32{7102, 999999, 7101, 7102, 7103})
+	if err != nil {
+		t.Fatalf("get social profiles by ids: %v", err)
+	}
+	if len(profiles) != 2 {
+		t.Fatalf("expected 2 existing profiles, got %d", len(profiles))
+	}
+	if _, ok := profiles[7101]; !ok {
+		t.Fatalf("expected profile for 7101")
+	}
+	if _, ok := profiles[7102]; !ok {
+		t.Fatalf("expected profile for 7102")
+	}
+	if _, ok := profiles[7103]; ok {
+		t.Fatalf("did not expect deleted profile 7103")
+	}
+	if _, ok := profiles[999999]; ok {
+		t.Fatalf("did not expect missing profile 999999")
+	}
+}
+
 func nullableDeletedAt(deleted bool) *time.Time {
 	if !deleted {
 		return nil


### PR DESCRIPTION
# Summary
- Adds focused coverage for batch friend profile lookup response shaping.
- Verifies social profile batch lookup filtering for missing and deleted commanders.
- Locks down online/offline presence and display field mapping in friend profile payloads.

# Changes
- Added `internal/answer/commander_friend_batch_get_test.go` for CS_50018/SC_50019 behavior and decode failure handling.
- Extended `internal/orm/friend_profiles_test.go` with batch ID lookup expectations (dedup input, missing IDs, deleted commanders).
