### PR TITLE
fix: clear dissolve chat data and cover chunk2 failures

### DIFF
--- a/internal/answer/guild_chunk2_handlers_test.go
+++ b/internal/answer/guild_chunk2_handlers_test.go
@@ -38,6 +38,7 @@ func TestGuildDissolveRemovesGuildChatMessages(t *testing.T) {
 	guildID := createResp.GetId()
 
 	execAnswerExternalTestSQLT(t, "INSERT INTO guild_chat_messages (guild_id, sender_id, sent_at, content) VALUES ($1, $2, NOW(), 'cleanup me')", int64(guildID), int64(leaderID))
+	execAnswerExternalTestSQLT(t, "INSERT INTO guild_chat_messages (guild_id, sender_id, sent_at, content) VALUES (0, $1, NOW(), 'cleanup placeholder')", int64(leaderID))
 
 	dissolveBuf, _ := proto.Marshal(&protobuf.CS_60010{Id: proto.Uint32(guildID)})
 	if _, _, err := answer.GuildDissolve(&dissolveBuf, leaderClient); err != nil {
@@ -56,6 +57,13 @@ func TestGuildDissolveRemovesGuildChatMessages(t *testing.T) {
 	if count != 0 {
 		t.Fatalf("expected dissolved guild chat messages removed, got %d", count)
 	}
+
+	if err := db.DefaultStore.Pool.QueryRow(t.Context(), "SELECT COUNT(*) FROM guild_chat_messages WHERE guild_id = 0 AND sender_id = $1", int64(leaderID)).Scan(&count); err != nil {
+		t.Fatalf("count placeholder guild chat messages: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected dissolved guild placeholder chat messages removed, got %d", count)
+	}
 }
 
 func TestGuildChunk2FailurePaths(t *testing.T) {
@@ -69,6 +77,7 @@ func TestGuildChunk2FailurePaths(t *testing.T) {
 
 	leaderClient := &connection.Client{Commander: createGuildCommander(t, leaderID)}
 	deputyClient := &connection.Client{Commander: createGuildCommander(t, deputyID)}
+	createGuildCommander(t, memberID)
 
 	createBuf, _ := proto.Marshal(&protobuf.CS_60001{
 		Faction:   proto.Uint32(1),

--- a/internal/orm/guild_core.go
+++ b/internal/orm/guild_core.go
@@ -795,6 +795,15 @@ func GuildDissolve(commanderID uint32, guildID uint32) error {
 		if _, err := tx.Exec(ctx, `DELETE FROM guild_chat_messages WHERE guild_id = $1`, int64(guildID)); err != nil {
 			return err
 		}
+		if _, err := tx.Exec(ctx, `
+DELETE FROM guild_chat_messages gcm
+USING guild_members gm
+WHERE gm.guild_id = $1
+  AND gm.commander_id = gcm.sender_id
+  AND gcm.guild_id = 0
+`, int64(guildID)); err != nil {
+			return err
+		}
 		if _, err := tx.Exec(ctx, `DELETE FROM guild_members WHERE guild_id = $1`, int64(guildID)); err != nil {
 			return err
 		}


### PR DESCRIPTION
# Summary
- Ensure guild dissolve fully clears guild-scoped runtime chat data so dissolved guilds do not retain stale chat history.
- Add focused regression coverage for guild admin packet failure cases across dissolve, duty reassignment, fire, impeach, quit, and guild-info modify flows.

# Changes
- Update guild dissolve transaction to delete `guild_chat_messages` rows for the target guild before membership teardown and soft delete.
- Add `internal/answer/guild_chunk2_handlers_test.go` with a dissolve cleanup regression test and a consolidated failure-path suite for the chunk 2 guild handlers.
