### PR TITLE
fix: use generic create-guild failures for non-name validation

### DIFF
--- a/internal/answer/create_guild.go
+++ b/internal/answer/create_guild.go
@@ -19,8 +19,11 @@ func CreateGuild(buffer *[]byte, client *connection.Client) (int, int, error) {
 	policy := payload.GetPolicy()
 	name := normalizeGuildText(payload.GetName())
 	manifesto := normalizeGuildText(payload.GetManifesto())
-	if !isValidGuildFaction(faction) || !isValidGuildPolicy(policy) || !isValidGuildName(name) || manifesto == "" {
+	if !isValidGuildName(name) {
 		response.Result = proto.Uint32(guildResultNameInvalid)
+		return client.SendMessage(60002, &response)
+	}
+	if !isValidGuildFaction(faction) || !isValidGuildPolicy(policy) || manifesto == "" {
 		return client.SendMessage(60002, &response)
 	}
 	createCost, err := loadGameSetUint("create_guild_cost")

--- a/internal/answer/guild_core_lifecycle_test.go
+++ b/internal/answer/guild_core_lifecycle_test.go
@@ -326,6 +326,80 @@ func TestGuildCreateBlockedByWaitCooldown(t *testing.T) {
 	}
 }
 
+func TestGuildCreateValidationResultCodes(t *testing.T) {
+	orm.InitDatabase()
+	seedGuildCoreConfig(t)
+	commanderID := uint32(86321)
+	cleanupGuildCoreData(t, commanderID)
+	defer cleanupGuildCoreData(t, commanderID)
+
+	client := &connection.Client{Commander: createGuildCommander(t, commanderID)}
+
+	testCases := []struct {
+		name     string
+		payload  *protobuf.CS_60001
+		expected uint32
+	}{
+		{
+			name: "invalid faction uses generic failure",
+			payload: &protobuf.CS_60001{
+				Faction:   proto.Uint32(3),
+				Policy:    proto.Uint32(1),
+				Name:      proto.String("VALIDNAME"),
+				Manifesto: proto.String("manifesto"),
+			},
+			expected: 1,
+		},
+		{
+			name: "invalid policy uses generic failure",
+			payload: &protobuf.CS_60001{
+				Faction:   proto.Uint32(1),
+				Policy:    proto.Uint32(3),
+				Name:      proto.String("VALIDNAME"),
+				Manifesto: proto.String("manifesto"),
+			},
+			expected: 1,
+		},
+		{
+			name: "empty manifesto uses generic failure",
+			payload: &protobuf.CS_60001{
+				Faction:   proto.Uint32(1),
+				Policy:    proto.Uint32(1),
+				Name:      proto.String("VALIDNAME"),
+				Manifesto: proto.String("  \t"),
+			},
+			expected: 1,
+		},
+		{
+			name: "invalid name uses 2015",
+			payload: &protobuf.CS_60001{
+				Faction:   proto.Uint32(1),
+				Policy:    proto.Uint32(1),
+				Name:      proto.String(""),
+				Manifesto: proto.String("manifesto"),
+			},
+			expected: 2015,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf, err := proto.Marshal(tc.payload)
+			if err != nil {
+				t.Fatalf("marshal payload: %v", err)
+			}
+			if _, _, err := answer.CreateGuild(&buf, client); err != nil {
+				t.Fatalf("CreateGuild failed: %v", err)
+			}
+			resp := &protobuf.SC_60002{}
+			decodeTestPacket(t, client, 60002, resp)
+			if resp.GetResult() != tc.expected {
+				t.Fatalf("expected result %d, got %d", tc.expected, resp.GetResult())
+			}
+		})
+	}
+}
+
 func TestGuildImpeachRejectsFutureLastLogin(t *testing.T) {
 	orm.InitDatabase()
 	seedGuildCoreConfig(t)


### PR DESCRIPTION
# Summary
- align guild creation result semantics so invalid/duplicate names map to `2015` while non-name validation failures stay generic
- keep `SC_60002` client behavior stable for name-specific error handling branches
- add packet-level coverage for guild creation validation result codes

# Changes
- update `CreateGuild` validation flow to return `2015` only for invalid names
- keep faction/policy/manifesto validation on generic non-zero response path
- add `TestGuildCreateValidationResultCodes` covering invalid faction, invalid policy, empty manifesto, and invalid name
