### PR TITLE
test: seed purchase fixtures for postgres fk constraints

### DIFF
--- a/internal/answer/guild_shop_purchase_test.go
+++ b/internal/answer/guild_shop_purchase_test.go
@@ -27,6 +27,20 @@ func seedConfigEntryJSON(t *testing.T, category string, key string, value any) {
 func seedGuildShopPurchaseEntry(t *testing.T, entry guildStoreEntry) {
 	t.Helper()
 	seedConfigEntryJSON(t, guildStoreConfigCategory, fmt.Sprintf("%d", entry.ID), entry)
+	if entry.Type == consts.DROP_TYPE_ITEM {
+		for _, itemID := range entry.Goods {
+			execAnswerExternalTestSQLT(
+				t,
+				"INSERT INTO items (id, name, rarity, shop_id, type, virtual_type) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT (id) DO NOTHING",
+				int64(itemID),
+				fmt.Sprintf("Guild Shop Item %d", itemID),
+				int64(1),
+				int64(-2),
+				int64(0),
+				int64(0),
+			)
+		}
+	}
 }
 
 func seedGuildShopSlot(t *testing.T, commanderID uint32, index uint32, goodsID uint32, count uint32) {

--- a/internal/answer/guild_shop_test.go
+++ b/internal/answer/guild_shop_test.go
@@ -60,6 +60,8 @@ func setupGuildShopCommander(t *testing.T, commanderID uint32) *orm.Commander {
 	os.Setenv("MODE", "test")
 	orm.InitDatabase()
 
+	execAnswerExternalTestSQLT(t, "INSERT INTO resources (id, item_id, name) VALUES ($1, $2, $3) ON CONFLICT (id) DO NOTHING", int64(8), int64(0), "Guild Coin")
+
 	name := fmt.Sprintf("Guild Shop Commander %d", commanderID)
 	if err := orm.CreateCommanderRoot(commanderID, commanderID, name, 0, 0); err != nil {
 		t.Fatalf("failed to create commander: %v", err)


### PR DESCRIPTION
# Summary
- stabilize guild chunk packet coverage by fixing guild shop test fixtures for postgres-backed runs
- ensure guild coin resource and purchasable item records exist before purchase-path assertions execute
- keep guild core membership/admin handlers reviewable with deterministic test setup under real database constraints

# Changes
- seed resource id `8` in guild shop commander test setup before writing `owned_resources`
- seed `items` rows for configured guild shop item rewards in purchase tests to satisfy FK-backed item grants
- leave runtime handler behavior unchanged; updates are limited to test fixtures and setup data
