### PR TITLE
feat: implement trade invitation packet flow

### DIFF
--- a/internal/answer/island/island_get_data.go
+++ b/internal/answer/island/island_get_data.go
@@ -93,6 +93,10 @@ func buildIslandPublicData(ownerID uint32, snapshot *orm.IslandSnapshot) *protob
 	}
 
 	inviteList, _ := orm.ListIslandShipInvites(ownerID)
+	tradeInviteList := []uint32{}
+	if tradeState, err := orm.GetCommanderIslandTradeInviteState(ownerID); err == nil {
+		tradeInviteList = append(tradeInviteList, tradeState.InvitedCommanderIDs...)
+	}
 	ships, _ := orm.ListIslandShips(ownerID)
 	shipList := make([]*protobuf.PB_ISLAND_SHIP, 0, len(ships))
 	for i := range ships {
@@ -148,7 +152,7 @@ func buildIslandPublicData(ownerID uint32, snapshot *orm.IslandSnapshot) *protob
 		TaskInfo:           &protobuf.PB_ISLAND_TASK{TaskIdListFinish: []uint32{}, TaskList: []*protobuf.PB_TASK{}, FocusId: proto.Uint32(0), TaskListRandom: []*protobuf.PB_TASK_RANDOM{}, WeekDailyTaskNum: proto.Uint32(0)},
 		TradeSys:           &protobuf.PB_ISLAND_TRADE_SYS{TodayEvent: proto.Uint32(0), TodayTrade: proto.Uint32(0), Effect: []*protobuf.PB_EVENT_EFFECT{}, TodayNum: []*protobuf.PB_TRADE_NUM{}, TradeList: []*protobuf.PB_ISLAND_TRADE{}, PresellList: []*protobuf.PB_TRADE_PRESELL{}},
 		BuildList:          []*protobuf.PB_ISLAND_BUILD{},
-		Treasure:           &protobuf.PB_ISLAND_TREASURE{WeekBuyNum: proto.Uint32(0), SellList: []*protobuf.PB_TRE_SELL_LIST{}, PriceList: []*protobuf.PB_TRE_HISTORY_PRICE{}, InviteList: []uint32{}},
+		Treasure:           &protobuf.PB_ISLAND_TREASURE{WeekBuyNum: proto.Uint32(0), SellList: []*protobuf.PB_TRE_SELL_LIST{}, PriceList: []*protobuf.PB_TRE_HISTORY_PRICE{}, InviteList: tradeInviteList},
 	}
 }
 

--- a/internal/answer/island/island_trade_invitation.go
+++ b/internal/answer/island/island_trade_invitation.go
@@ -1,0 +1,58 @@
+package island
+
+import (
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func IslandTradeInvitation(buffer *[]byte, client *connection.Client) (int, int, error) {
+	var request protobuf.CS_21245
+	if err := proto.Unmarshal(*buffer, &request); err != nil {
+		return 0, 21246, err
+	}
+
+	response := protobuf.SC_21246{Result: proto.Uint32(1)}
+	candidateTargets := normalizeCommanderIDs(request.GetFriendList(), client.Commander.CommanderID)
+	if len(candidateTargets) == 0 {
+		return client.SendMessage(21246, &response)
+	}
+
+	validTargets := make([]uint32, 0, len(candidateTargets))
+	for _, targetCommanderID := range candidateTargets {
+		if err := orm.CommanderExists(targetCommanderID); err != nil {
+			continue
+		}
+		validTargets = append(validTargets, targetCommanderID)
+	}
+	if len(validTargets) == 0 {
+		return client.SendMessage(21246, &response)
+	}
+
+	inviteState, err := orm.GetOrCreateCommanderIslandTradeInviteState(client.Commander.CommanderID)
+	if err != nil {
+		return client.SendMessage(21246, &response)
+	}
+	inviteState.InvitedCommanderIDs = mergeUniqueCommanderIDs(inviteState.InvitedCommanderIDs, validTargets)
+	if err := orm.SaveCommanderIslandTradeInviteState(inviteState); err != nil {
+		return client.SendMessage(21246, &response)
+	}
+
+	if client.Server != nil {
+		for _, targetCommanderID := range validTargets {
+			peer, ok := client.Server.FindClientByCommander(targetCommanderID)
+			if !ok {
+				continue
+			}
+			peer.SendMessage(21247, &protobuf.SC_21247{
+				IslandId: proto.Uint32(client.Commander.CommanderID),
+				MapId:    proto.Uint32(request.GetMapId()),
+				Price:    proto.Uint32(request.GetPrice()),
+			})
+		}
+	}
+
+	response.Result = proto.Uint32(0)
+	return client.SendMessage(21246, &response)
+}

--- a/internal/answer/island/island_trade_invitation_test.go
+++ b/internal/answer/island/island_trade_invitation_test.go
@@ -1,0 +1,128 @@
+package island
+
+import (
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/db"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestIslandTradeInvitationSuccessPersistsAndPushes(t *testing.T) {
+	globalIslandRuntimeState.resetForTest()
+	inviter := setupHandlerCommander(t)
+	onlineID := inviter.Commander.CommanderID + 1
+	offlineID := inviter.Commander.CommanderID + 2
+
+	if err := orm.CreateCommanderRoot(onlineID, onlineID, "online target", 0, 0); err != nil {
+		t.Fatalf("create online target commander: %v", err)
+	}
+	if err := orm.CreateCommanderRoot(offlineID, offlineID, "offline target", 0, 0); err != nil {
+		t.Fatalf("create offline target commander: %v", err)
+	}
+	onlineCommander := orm.Commander{CommanderID: onlineID}
+	if err := onlineCommander.Load(); err != nil {
+		t.Fatalf("load online target commander: %v", err)
+	}
+	onlineTarget := &connection.Client{Commander: &onlineCommander}
+	onlineTarget.Hash = inviter.Hash + 1
+	onlineTarget.Server = inviter.Server
+	inviter.Server.AddClient(inviter)
+	inviter.Server.AddClient(onlineTarget)
+
+	friendList := []uint32{
+		onlineID,
+		offlineID,
+		onlineID,
+		0,
+		inviter.Commander.CommanderID,
+		4294967295,
+	}
+	payload, err := proto.Marshal(&protobuf.CS_21245{
+		FriendList: friendList,
+		MapId:      proto.Uint32(1003),
+		Price:      proto.Uint32(777),
+	})
+	if err != nil {
+		t.Fatalf("marshal invitation payload: %v", err)
+	}
+
+	if _, _, err := IslandTradeInvitation(&payload, inviter); err != nil {
+		t.Fatalf("trade invitation handler failed: %v", err)
+	}
+
+	var ack protobuf.SC_21246
+	decodePacketAt(t, inviter, 0, 21246, &ack)
+	if ack.GetResult() != 0 {
+		t.Fatalf("expected success ack, got %d", ack.GetResult())
+	}
+
+	var push protobuf.SC_21247
+	decodePacketAt(t, onlineTarget, 0, 21247, &push)
+	if push.GetIslandId() != inviter.Commander.CommanderID {
+		t.Fatalf("expected inviter id %d in push, got %d", inviter.Commander.CommanderID, push.GetIslandId())
+	}
+	if push.GetMapId() != 1003 || push.GetPrice() != 777 {
+		t.Fatalf("unexpected push payload map_id=%d price=%d", push.GetMapId(), push.GetPrice())
+	}
+
+	state, err := orm.GetCommanderIslandTradeInviteState(inviter.Commander.CommanderID)
+	if err != nil {
+		t.Fatalf("load trade invite state: %v", err)
+	}
+	if len(state.InvitedCommanderIDs) != 2 {
+		t.Fatalf("expected 2 invited commander ids, got %v", state.InvitedCommanderIDs)
+	}
+	if state.InvitedCommanderIDs[0] != onlineID || state.InvitedCommanderIDs[1] != offlineID {
+		t.Fatalf("unexpected persisted invite ids: %v", state.InvitedCommanderIDs)
+	}
+
+	inviter.Buffer.Reset()
+	getDataPayload, _ := proto.Marshal(&protobuf.CS_21200{IslandId: proto.Uint32(inviter.Commander.CommanderID)})
+	if _, _, err := IslandGetData(&getDataPayload, inviter); err != nil {
+		t.Fatalf("island get data failed: %v", err)
+	}
+	var getDataResp protobuf.SC_21201
+	decodePacketAt(t, inviter, 0, 21201, &getDataResp)
+	invites := getDataResp.GetIsland().GetPublicData().GetTreasure().GetInviteList()
+	if len(invites) != 2 {
+		t.Fatalf("expected 2 treasure invite ids, got %v", invites)
+	}
+	if invites[0] != onlineID || invites[1] != offlineID {
+		t.Fatalf("unexpected treasure invite list: %v", invites)
+	}
+}
+
+func TestIslandTradeInvitationRejectsInvalidTargets(t *testing.T) {
+	globalIslandRuntimeState.resetForTest()
+	inviter := setupHandlerCommander(t)
+
+	payload, err := proto.Marshal(&protobuf.CS_21245{
+		FriendList: []uint32{0, inviter.Commander.CommanderID},
+		MapId:      proto.Uint32(1003),
+		Price:      proto.Uint32(555),
+	})
+	if err != nil {
+		t.Fatalf("marshal invitation payload: %v", err)
+	}
+
+	if _, _, err := IslandTradeInvitation(&payload, inviter); err != nil {
+		t.Fatalf("trade invitation handler failed: %v", err)
+	}
+
+	var ack protobuf.SC_21246
+	decodePacketAt(t, inviter, 0, 21246, &ack)
+	if ack.GetResult() == 0 {
+		t.Fatalf("expected non-zero ack for invalid target list")
+	}
+
+	_, err = orm.GetCommanderIslandTradeInviteState(inviter.Commander.CommanderID)
+	if err == nil {
+		t.Fatalf("expected no persisted invite state on validation failure")
+	}
+	if !db.IsNotFound(err) {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}

--- a/internal/answer/island_handlers_bridge.go
+++ b/internal/answer/island_handlers_bridge.go
@@ -351,6 +351,10 @@ func IslandSignInInvitation(buffer *[]byte, client *connection.Client) (int, int
 	return island.IslandSignInInvitation(buffer, client)
 }
 
+func IslandTradeInvitation(buffer *[]byte, client *connection.Client) (int, int, error) {
+	return island.IslandTradeInvitation(buffer, client)
+}
+
 func HandleIslandGetGiftTag(buffer *[]byte, client *connection.Client) (int, int, error) {
 	return island.HandleIslandGetGiftTag(buffer, client)
 }

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -378,6 +378,12 @@ type CommanderIslandSocialState struct {
 	BlackList            []byte
 }
 
+type CommanderIslandTradeInviteState struct {
+	CommanderID         int64
+	InvitedCommanderIds []byte
+	UpdatedAt           pgtype.Timestamptz
+}
+
 type CommanderItem struct {
 	CommanderID int64
 	ItemID      int64

--- a/internal/db/migrations/0072_island_trade_invite_states.sql
+++ b/internal/db/migrations/0072_island_trade_invite_states.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS commander_island_trade_invite_states (
+  commander_id bigint PRIMARY KEY REFERENCES commanders(commander_id) ON DELETE CASCADE,
+  invited_commander_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+  updated_at timestamptz NOT NULL DEFAULT NOW()
+);

--- a/internal/entrypoint/island_packet_registry_test.go
+++ b/internal/entrypoint/island_packet_registry_test.go
@@ -1,0 +1,25 @@
+package entrypoint
+
+import (
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/packets"
+)
+
+func TestRegisterPacketsIncludesIslandTradeInvitationHandler(t *testing.T) {
+	previous := packets.PacketDecisionFn
+	t.Cleanup(func() {
+		packets.PacketDecisionFn = previous
+	})
+
+	packets.PacketDecisionFn = map[int][]packets.PacketHandler{}
+	registerPackets()
+
+	handlers, ok := packets.PacketDecisionFn[21245]
+	if !ok {
+		t.Fatalf("expected packet 21245 to be registered")
+	}
+	if len(handlers) == 0 {
+		t.Fatalf("expected packet 21245 to have handlers")
+	}
+}

--- a/internal/entrypoint/packet_registry.go
+++ b/internal/entrypoint/packet_registry.go
@@ -620,6 +620,7 @@ func registerPackets() {
 	packets.RegisterPacketHandler(21215, []packets.PacketHandler{answer.IslandHeartbeat})
 	packets.RegisterPacketHandler(21229, []packets.PacketHandler{answer.HandleIslandRecordLastPosition})
 	packets.RegisterPacketHandler(21230, []packets.PacketHandler{answer.HandleIslandReconnect})
+	packets.RegisterPacketHandler(21245, []packets.PacketHandler{answer.IslandTradeInvitation})
 	packets.RegisterPacketHandler(21700, []packets.PacketHandler{answer.IslandAnimationOp})
 	packets.RegisterPacketHandler(21312, []packets.PacketHandler{answer.IslandSignInInvitation})
 	packets.RegisterPacketHandler(21315, []packets.PacketHandler{answer.HandleIslandGetGiftTag})

--- a/internal/orm/island_trade_invite_state.go
+++ b/internal/orm/island_trade_invite_state.go
@@ -1,0 +1,83 @@
+package orm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/ggmolly/belfast/internal/db"
+)
+
+type CommanderIslandTradeInviteState struct {
+	CommanderID         uint32
+	InvitedCommanderIDs []uint32
+	UpdatedAt           time.Time
+}
+
+func GetCommanderIslandTradeInviteState(commanderID uint32) (*CommanderIslandTradeInviteState, error) {
+	if db.DefaultStore == nil {
+		return nil, fmt.Errorf("database is not initialized")
+	}
+
+	state := &CommanderIslandTradeInviteState{}
+	var invitedRaw []byte
+	err := db.DefaultStore.Pool.QueryRow(context.Background(), `
+SELECT commander_id, invited_commander_ids, updated_at
+FROM commander_island_trade_invite_states
+WHERE commander_id = $1
+`, int64(commanderID)).Scan(&state.CommanderID, &invitedRaw, &state.UpdatedAt)
+	err = db.MapNotFound(err)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(invitedRaw) == 0 {
+		state.InvitedCommanderIDs = []uint32{}
+		return state, nil
+	}
+	if err := json.Unmarshal(invitedRaw, &state.InvitedCommanderIDs); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func GetOrCreateCommanderIslandTradeInviteState(commanderID uint32) (*CommanderIslandTradeInviteState, error) {
+	state, err := GetCommanderIslandTradeInviteState(commanderID)
+	if err == nil {
+		return state, nil
+	}
+	if !db.IsNotFound(err) {
+		return nil, err
+	}
+
+	state = &CommanderIslandTradeInviteState{
+		CommanderID:         commanderID,
+		InvitedCommanderIDs: []uint32{},
+	}
+	if err := SaveCommanderIslandTradeInviteState(state); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func SaveCommanderIslandTradeInviteState(state *CommanderIslandTradeInviteState) error {
+	if db.DefaultStore == nil {
+		return fmt.Errorf("database is not initialized")
+	}
+
+	invitedRaw, err := json.Marshal(state.InvitedCommanderIDs)
+	if err != nil {
+		return err
+	}
+
+	_, err = db.DefaultStore.Pool.Exec(context.Background(), `
+INSERT INTO commander_island_trade_invite_states (commander_id, invited_commander_ids, updated_at)
+VALUES ($1, $2, NOW())
+ON CONFLICT (commander_id)
+DO UPDATE SET
+  invited_commander_ids = EXCLUDED.invited_commander_ids,
+  updated_at = NOW()
+`, int64(state.CommanderID), invitedRaw)
+	return err
+}


### PR DESCRIPTION
# Summary
- Adds server support for `CS_21245` so island trade invitations are handled with a direct `SC_21246` acknowledgement.
- Persists inviter trade invite targets and surfaces that state through island data snapshots in `PB_ISLAND_TREASURE.invite_list`.
- Sends best-effort `SC_21247` trade notifications to online invited commanders with inviter ID, map ID, and price payload.

# Changes
- Registers packet `21245` in the packet registry and bridges it through the island handler entrypoint.
- Implements `IslandTradeInvitation` request decoding, target normalization/filtering, persistence updates, and async peer push behavior.
- Adds `commander_island_trade_invite_states` migration plus ORM read/write helpers and regenerates SQLC models.
- Adds island handler tests for success, dedupe/filtering, persistence/readback, and invalid-target rejection.
- Adds an entrypoint registry test that asserts packet `21245` is registered with at least one handler.
