### PR TITLE
fix: push ship intimacy on validate success

### DIFF
--- a/internal/answer/ship_action_validate.go
+++ b/internal/answer/ship_action_validate.go
@@ -13,9 +13,21 @@ func HandleShipActionValidate(buffer *[]byte, client *connection.Client) (int, i
 	}
 
 	response := protobuf.SC_12021{Result: proto.Uint32(1)}
-	if _, ok := client.Commander.OwnedShipsMap[data.GetShipId()]; ok {
+	ship, ok := client.Commander.OwnedShipsMap[data.GetShipId()]
+	if ok {
 		response.Result = proto.Uint32(0)
 	}
 
-	return client.SendMessage(12021, &response)
+	if _, _, err := client.SendMessage(12021, &response); err != nil {
+		return 0, 12021, err
+	}
+
+	if ok {
+		push := protobuf.SC_12019{Intimacy: proto.Uint32(ship.Intimacy)}
+		if _, _, err := client.SendMessage(12019, &push); err != nil {
+			return 0, 12019, err
+		}
+	}
+
+	return 0, 12021, nil
 }

--- a/internal/answer/ship_action_validate_test.go
+++ b/internal/answer/ship_action_validate_test.go
@@ -12,7 +12,7 @@ import (
 func TestShipAction12020Success(t *testing.T) {
 	commander := &orm.Commander{
 		OwnedShipsMap: map[uint32]*orm.OwnedShip{
-			10: {ID: 10},
+			10: {ID: 10, Intimacy: 7300},
 		},
 	}
 	client := &connection.Client{Commander: commander}
@@ -30,18 +30,19 @@ func TestShipAction12020Success(t *testing.T) {
 		t.Fatalf("expected packet 12021, got %d", packetID)
 	}
 
-	data := client.Buffer.Bytes()
-	if len(data) < 7 {
-		t.Fatalf("expected buffer to include header and payload")
-	}
-	data = data[7:]
-
 	var response protobuf.SC_12021
-	if err := proto.Unmarshal(data, &response); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
-	}
+	offset := decodePacketAt(t, client, 0, 12021, &response)
 	if response.GetResult() != 0 {
 		t.Fatalf("expected result 0, got %d", response.GetResult())
+	}
+
+	var push protobuf.SC_12019
+	offset = decodePacketAt(t, client, offset, 12019, &push)
+	if push.GetIntimacy() != 7300 {
+		t.Fatalf("expected intimacy 7300, got %d", push.GetIntimacy())
+	}
+	if offset != len(client.Buffer.Bytes()) {
+		t.Fatalf("expected exactly two packets in buffer")
 	}
 }
 
@@ -62,18 +63,13 @@ func TestShipAction12020MissingShip(t *testing.T) {
 		t.Fatalf("expected packet 12021, got %d", packetID)
 	}
 
-	data := client.Buffer.Bytes()
-	if len(data) < 7 {
-		t.Fatalf("expected buffer to include header and payload")
-	}
-	data = data[7:]
-
 	var response protobuf.SC_12021
-	if err := proto.Unmarshal(data, &response); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
-	}
+	offset := decodePacketAt(t, client, 0, 12021, &response)
 	if response.GetResult() != 1 {
 		t.Fatalf("expected result 1, got %d", response.GetResult())
+	}
+	if offset != len(client.Buffer.Bytes()) {
+		t.Fatalf("expected no push packet for missing ship")
 	}
 }
 
@@ -88,5 +84,8 @@ func TestShipAction12020BadPayload(t *testing.T) {
 	}
 	if packetID != 12021 {
 		t.Fatalf("expected packet 12021, got %d", packetID)
+	}
+	if len(client.Buffer.Bytes()) != 0 {
+		t.Fatalf("expected no response packets on bad payload")
 	}
 }


### PR DESCRIPTION
# Summary
- Sends `SC_12019` intimacy updates after successful ship action validation so the active ship likability stays in sync.
- Preserves existing `CS_12020 -> SC_12021` validation semantics for success, missing-ship, and bad-payload paths.

# Changes
- Updated `HandleShipActionValidate` to always send `SC_12021` first and conditionally push `SC_12019` when the target ship exists.
- Extended `ship_action_validate` tests to assert packet ordering, `SC_12019` payload correctness, and no false-positive push packets.
