### PR TITLE
fix: push common flag updates via sc_11802

### DIFF
--- a/internal/answer/cancel_common_flag_command.go
+++ b/internal/answer/cancel_common_flag_command.go
@@ -15,6 +15,14 @@ func CancelCommonFlagCommand(buffer *[]byte, client *connection.Client) (int, in
 	response := protobuf.SC_11022{Result: proto.Uint32(0)}
 	if err := orm.ClearCommanderCommonFlag(client.Commander.CommanderID, payload.GetFlagId()); err != nil {
 		response.Result = proto.Uint32(1)
+		return client.SendMessage(11022, &response)
 	}
-	return client.SendMessage(11022, &response)
+	bytesWritten, packetID, err := client.SendMessage(11022, &response)
+	if err != nil {
+		return bytesWritten, packetID, err
+	}
+	if _, _, err := sendCommonFlagPush(client, payload.GetFlagId(), false); err != nil {
+		return bytesWritten, packetID, err
+	}
+	return bytesWritten, packetID, nil
 }

--- a/internal/answer/common_flag_push.go
+++ b/internal/answer/common_flag_push.go
@@ -1,0 +1,19 @@
+package answer
+
+import (
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/protobuf"
+	"google.golang.org/protobuf/proto"
+)
+
+func sendCommonFlagPush(client *connection.Client, flagID uint32, enabled bool) (int, int, error) {
+	value := uint32(0)
+	if enabled {
+		value = 1
+	}
+	response := protobuf.SC_11802{
+		Id:    proto.Uint32(flagID),
+		Value: proto.Uint32(value),
+	}
+	return client.SendMessage(11802, &response)
+}

--- a/internal/answer/player_updates_test.go
+++ b/internal/answer/player_updates_test.go
@@ -59,9 +59,31 @@ func TestUpdateCommonFlagCommand(t *testing.T) {
 	if _, _, err := UpdateCommonFlagCommand(&buffer, client); err != nil {
 		t.Fatalf("update common flag failed: %v", err)
 	}
+	var updateResponse protobuf.SC_11020
+	offset := decodePacketAt(t, client, 0, 11020, &updateResponse)
+	if updateResponse.GetResult() != 0 {
+		t.Fatalf("expected update result 0, got %d", updateResponse.GetResult())
+	}
+	var pushResponse protobuf.SC_11802
+	decodePacketAt(t, client, offset, 11802, &pushResponse)
+	if pushResponse.GetId() != 1000009 || pushResponse.GetValue() != 1 {
+		t.Fatalf("expected SC_11802{id=1000009,value=1}, got id=%d value=%d", pushResponse.GetId(), pushResponse.GetValue())
+	}
 	count := queryAnswerTestInt64(t, "SELECT COUNT(*) FROM commander_common_flags WHERE commander_id = $1 AND flag_id = $2", int64(client.Commander.CommanderID), int64(1000009))
 	if count == 0 {
 		t.Fatalf("load flag entry: expected row")
+	}
+}
+
+func TestUpdateCommonFlagCommandFailureNoPush(t *testing.T) {
+	client := setupPlayerUpdateTest(t)
+	buffer := []byte{0x01}
+	_, _, err := UpdateCommonFlagCommand(&buffer, client)
+	if err == nil {
+		t.Fatalf("expected unmarshal failure")
+	}
+	if client.Buffer.Len() != 0 {
+		t.Fatalf("expected no packets on decode failure")
 	}
 }
 
@@ -78,9 +100,31 @@ func TestCancelCommonFlagCommand(t *testing.T) {
 	if _, _, err := CancelCommonFlagCommand(&buffer, client); err != nil {
 		t.Fatalf("cancel common flag failed: %v", err)
 	}
+	var cancelResponse protobuf.SC_11022
+	offset := decodePacketAt(t, client, 0, 11022, &cancelResponse)
+	if cancelResponse.GetResult() != 0 {
+		t.Fatalf("expected cancel result 0, got %d", cancelResponse.GetResult())
+	}
+	var pushResponse protobuf.SC_11802
+	decodePacketAt(t, client, offset, 11802, &pushResponse)
+	if pushResponse.GetId() != 1000001 || pushResponse.GetValue() != 0 {
+		t.Fatalf("expected SC_11802{id=1000001,value=0}, got id=%d value=%d", pushResponse.GetId(), pushResponse.GetValue())
+	}
 	count := queryAnswerTestInt64(t, "SELECT COUNT(*) FROM commander_common_flags WHERE commander_id = $1 AND flag_id = $2", int64(client.Commander.CommanderID), int64(1000001))
 	if count != 0 {
 		t.Fatalf("expected flag to be removed")
+	}
+}
+
+func TestCancelCommonFlagCommandDecodeFailureNoPush(t *testing.T) {
+	client := setupPlayerUpdateTest(t)
+	buffer := []byte{0x01}
+	_, _, err := CancelCommonFlagCommand(&buffer, client)
+	if err == nil {
+		t.Fatalf("expected unmarshal failure")
+	}
+	if client.Buffer.Len() != 0 {
+		t.Fatalf("expected no packets on decode failure")
 	}
 }
 

--- a/internal/answer/update_common_flag_command.go
+++ b/internal/answer/update_common_flag_command.go
@@ -17,6 +17,14 @@ func UpdateCommonFlagCommand(buffer *[]byte, client *connection.Client) (int, in
 	}
 	if err := orm.SetCommanderCommonFlag(client.Commander.CommanderID, payload.GetFlagId()); err != nil {
 		response.Result = proto.Uint32(1)
+		return client.SendMessage(11020, &response)
 	}
-	return client.SendMessage(11020, &response)
+	bytesWritten, packetID, err := client.SendMessage(11020, &response)
+	if err != nil {
+		return bytesWritten, packetID, err
+	}
+	if _, _, err := sendCommonFlagPush(client, payload.GetFlagId(), true); err != nil {
+		return bytesWritten, packetID, err
+	}
+	return bytesWritten, packetID, nil
 }


### PR DESCRIPTION
# Summary
- Emit `SC_11802` common-flag updates after successful `CS_11019` and `CS_11021` handling so clients can mirror flag state changes immediately.
- Keep existing `SC_11020` and `SC_11022` response behavior intact while adding deterministic push behavior on success only.

# Changes
- Added a shared `sendCommonFlagPush` helper that serializes `SC_11802{id,value}` for common-flag updates.
- Updated common-flag set/clear handlers to send `SC_11802` after successful DB mutation and response emission.
- Extended player update tests to verify success-path packet ordering/content and decode-failure no-push behavior.
