### PR TITLE
feat: add sc_14200 special weapon sync sender

### DIFF
--- a/internal/answer/special_weapon_sync.go
+++ b/internal/answer/special_weapon_sync.go
@@ -1,0 +1,18 @@
+package answer
+
+import (
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+)
+
+func SendSpecialWeaponSync(client *connection.Client) (int, int, error) {
+	response := protobuf.SC_14200{
+		SpweaponList: orm.ToProtoOwnedSpWeaponList(client.Commander.OwnedSpWeapons),
+	}
+	if response.SpweaponList == nil {
+		response.SpweaponList = []*protobuf.SPWEAPONINFO{}
+	}
+
+	return client.SendMessage(14200, &response)
+}

--- a/internal/answer/special_weapon_sync_test.go
+++ b/internal/answer/special_weapon_sync_test.go
@@ -1,0 +1,54 @@
+package answer
+
+import (
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
+	"github.com/ggmolly/belfast/internal/protobuf"
+)
+
+func TestSendSpecialWeaponSyncSerializesOwnedWeapons(t *testing.T) {
+	client := &connection.Client{
+		Commander: &orm.Commander{
+			OwnedSpWeapons: []orm.OwnedSpWeapon{
+				{ID: 11, TemplateID: 101, Attr1: 1, Attr2: 2, AttrTemp1: 3, AttrTemp2: 4, Effect: 5, Pt: 6},
+				{ID: 12, TemplateID: 202, Attr1: 7, Attr2: 8, AttrTemp1: 9, AttrTemp2: 10, Effect: 11, Pt: 12},
+			},
+		},
+	}
+
+	if _, _, err := SendSpecialWeaponSync(client); err != nil {
+		t.Fatalf("send special weapon sync failed: %v", err)
+	}
+
+	var response protobuf.SC_14200
+	decodePacketAt(t, client, 0, 14200, &response)
+
+	if len(response.GetSpweaponList()) != 2 {
+		t.Fatalf("expected 2 special weapons, got %d", len(response.GetSpweaponList()))
+	}
+
+	first := response.GetSpweaponList()[0]
+	if first.GetId() != 11 || first.GetTemplateId() != 101 {
+		t.Fatalf("unexpected first spweapon identity: id=%d template=%d", first.GetId(), first.GetTemplateId())
+	}
+	if first.GetAttr_1() != 1 || first.GetAttr_2() != 2 || first.GetAttrTemp_1() != 3 || first.GetAttrTemp_2() != 4 || first.GetEffect() != 5 || first.GetPt() != 6 {
+		t.Fatalf("unexpected first spweapon attributes")
+	}
+}
+
+func TestSendSpecialWeaponSyncUsesEmptyListWhenNoWeapons(t *testing.T) {
+	client := &connection.Client{Commander: &orm.Commander{}}
+
+	if _, _, err := SendSpecialWeaponSync(client); err != nil {
+		t.Fatalf("send special weapon sync failed: %v", err)
+	}
+
+	var response protobuf.SC_14200
+	decodePacketAt(t, client, 0, 14200, &response)
+
+	if len(response.GetSpweaponList()) != 0 {
+		t.Fatalf("expected empty special weapon list, got %d", len(response.GetSpweaponList()))
+	}
+}


### PR DESCRIPTION
# Summary
- Add a dedicated `SC_14200` sender that can push a full special-weapon resync payload when a future runtime trigger requires it.
- Reuse existing owned special-weapon conversion so payload shape stays aligned with current `SPWEAPONINFO` serialization.
- Keep existing login and mutation flows unchanged by introducing the sender as an explicit helper rather than wiring a new automatic trigger.

# Changes
- Added `SendSpecialWeaponSync` in `internal/answer/special_weapon_sync.go` to emit packet `14200` with commander-owned special weapons.
- Ensured empty owned-weapon state is serialized as a valid empty list payload.
- Added `internal/answer/special_weapon_sync_test.go` to verify full field serialization and empty-list behavior.
