### PR TITLE
fix: codify sc_11706 bootstrap flow

### DIFF
--- a/internal/answer/juustagram_handlers_test.go
+++ b/internal/answer/juustagram_handlers_test.go
@@ -186,6 +186,23 @@ func TestJuustagramMessageRangeSkipsUnpublished(t *testing.T) {
 	}
 }
 
+func TestJuustagramMessageRangeDecodeFailure(t *testing.T) {
+	initJuustagramHandlerTestDB(t)
+	commander := &orm.Commander{CommanderID: 1001}
+	client := &connection.Client{Commander: commander}
+	buffer := []byte{0x01}
+	_, packetID, err := JuustagramMessageRange(&buffer, client)
+	if err == nil {
+		t.Fatalf("expected decode error")
+	}
+	if packetID != consts.JuustagramPacketRangeResp {
+		t.Fatalf("expected packet %d, got %d", consts.JuustagramPacketRangeResp, packetID)
+	}
+	if client.Buffer.Len() != 0 {
+		t.Fatalf("expected no response payload on decode failure")
+	}
+}
+
 func TestJuustagramOpMissingLanguageUsesEmptyText(t *testing.T) {
 	initJuustagramHandlerTestDB(t)
 	execAnswerTestSQLT(t, "DELETE FROM juustagram_message_states")

--- a/internal/answer/juustagram_message_range.go
+++ b/internal/answer/juustagram_message_range.go
@@ -20,8 +20,17 @@ func JuustagramMessageRange(buffer *[]byte, client *connection.Client) (int, int
 	if client.Commander == nil {
 		return 0, consts.JuustagramPacketRangeResp, errors.New("missing commander")
 	}
-	indexBegin := payload.GetIndexBegin()
-	indexEnd := payload.GetIndexEnd()
+	// SC_11700 remains intentionally unsupported because current client bootstrap
+	// flow requests Juustagram messages via CS_11705 and consumes SC_11706.
+	messages, err := buildJuustagramMessagesForRange(client.Commander.CommanderID, payload.GetIndexBegin(), payload.GetIndexEnd())
+	if err != nil {
+		return 0, consts.JuustagramPacketRangeResp, err
+	}
+	response := protobuf.SC_11706{InsMessageList: messages}
+	return client.SendMessage(consts.JuustagramPacketRangeResp, &response)
+}
+
+func buildJuustagramMessagesForRange(commanderID uint32, indexBegin uint32, indexEnd uint32) ([]*protobuf.INS_MESSAGE, error) {
 	templates := make([]orm.JuustagramTemplate, 0)
 	for id := indexBegin; id <= indexEnd; id++ {
 		template, err := orm.GetJuustagramTemplate(id)
@@ -32,7 +41,7 @@ func JuustagramMessageRange(buffer *[]byte, client *connection.Client) (int, int
 				}
 				continue
 			}
-			return 0, consts.JuustagramPacketRangeResp, err
+			return nil, err
 		}
 		templates = append(templates, *template)
 		if id == indexEnd {
@@ -43,18 +52,17 @@ func JuustagramMessageRange(buffer *[]byte, client *connection.Client) (int, int
 	messages := make([]*protobuf.INS_MESSAGE, 0, len(templates))
 	for _, template := range templates {
 		if ok, err := isPublishableJuustagramTemplate(template); err != nil {
-			return 0, consts.JuustagramPacketRangeResp, err
+			return nil, err
 		} else if !ok {
 			// Skip templates that are not ready to be served to clients.
-			logJuustagramSkip(template, client.Commander.CommanderID)
+			logJuustagramSkip(template, commanderID)
 			continue
 		}
-		message, err := BuildJuustagramMessage(client.Commander.CommanderID, template.ID, now)
+		message, err := BuildJuustagramMessage(commanderID, template.ID, now)
 		if err != nil {
-			return 0, consts.JuustagramPacketRangeResp, err
+			return nil, err
 		}
 		messages = append(messages, message)
 	}
-	response := protobuf.SC_11706{InsMessageList: messages}
-	return client.SendMessage(consts.JuustagramPacketRangeResp, &response)
+	return messages, nil
 }

--- a/internal/entrypoint/juustagram_packet_registry_test.go
+++ b/internal/entrypoint/juustagram_packet_registry_test.go
@@ -1,0 +1,25 @@
+package entrypoint
+
+import (
+	"testing"
+
+	"github.com/ggmolly/belfast/internal/packets"
+)
+
+func TestRegisterPacketsJuustagramRangeRegisteredWithoutSC11700Inbound(t *testing.T) {
+	previous := packets.PacketDecisionFn
+	t.Cleanup(func() {
+		packets.PacketDecisionFn = previous
+	})
+
+	packets.PacketDecisionFn = map[int][]packets.PacketHandler{}
+	registerPackets()
+
+	rangeHandlers, ok := packets.PacketDecisionFn[11705]
+	if !ok || len(rangeHandlers) == 0 {
+		t.Fatalf("expected packet 11705 to be registered")
+	}
+	if _, ok := packets.PacketDecisionFn[11700]; ok {
+		t.Fatalf("did not expect packet 11700 to be registered as inbound")
+	}
+}


### PR DESCRIPTION
# Summary
- Keep Juustagram bootstrap behavior aligned with the active client flow by treating `CS_11705 -> SC_11706` as the canonical message list path.
- Make the `SC_11700` compatibility decision explicit so it is not accidentally added as an inbound packet route.

# Changes
- Refactored Juustagram range message building into a shared helper and documented why `SC_11700` is intentionally not emitted.
- Added malformed `CS_11705` decode-failure coverage to ensure no response payload is sent on invalid input.
- Added packet registry coverage proving `11705` is registered and `11700` is not registered as an inbound handler.
