### PR TITLE
fix: add charge success push orchestration

### DIFF
--- a/internal/answer/charge_success_push.go
+++ b/internal/answer/charge_success_push.go
@@ -1,12 +1,13 @@
 package answer
 
 import (
+	"context"
 	"errors"
-	"sync"
 
 	"github.com/ggmolly/belfast/internal/connection"
 	"github.com/ggmolly/belfast/internal/orm"
 	"github.com/ggmolly/belfast/internal/protobuf"
+	"github.com/jackc/pgx/v5"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -17,11 +18,6 @@ type ChargeSuccessEvent struct {
 	GemFree uint32
 }
 
-var (
-	chargeSuccessDedupMu  sync.Mutex
-	processedChargeEvents = map[uint32]map[string]struct{}{}
-)
-
 func ApplyChargeSuccessEvent(commander *orm.Commander, client *connection.Client, event ChargeSuccessEvent) error {
 	if commander == nil {
 		return errors.New("missing commander")
@@ -29,21 +25,35 @@ func ApplyChargeSuccessEvent(commander *orm.Commander, client *connection.Client
 	if event.ShopID == 0 || event.PayID == "" {
 		return errors.New("invalid charge success event")
 	}
-	if wasProcessedChargeEvent(commander.CommanderID, event.PayID) {
+	ctx := context.Background()
+	processed := false
+	err := orm.WithPGXTx(ctx, func(tx pgx.Tx) error {
+		inserted, err := orm.TryRecordChargeSuccessEventTx(ctx, tx, commander.CommanderID, event.PayID)
+		if err != nil {
+			return err
+		}
+		if !inserted {
+			return nil
+		}
+		if event.Gem > 0 {
+			if err := commander.AddResourceTx(ctx, tx, 4, event.Gem); err != nil {
+				return err
+			}
+		}
+		if event.GemFree > 0 {
+			if err := commander.AddResourceTx(ctx, tx, 14, event.GemFree); err != nil {
+				return err
+			}
+		}
+		processed = true
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if !processed {
 		return nil
 	}
-
-	if event.Gem > 0 {
-		if err := commander.AddResource(4, event.Gem); err != nil {
-			return err
-		}
-	}
-	if event.GemFree > 0 {
-		if err := commander.AddResource(14, event.GemFree); err != nil {
-			return err
-		}
-	}
-	markChargeEventProcessed(commander.CommanderID, event.PayID)
 
 	if client == nil {
 		return nil
@@ -54,34 +64,6 @@ func ApplyChargeSuccessEvent(commander *orm.Commander, client *connection.Client
 		Gem:     proto.Uint32(event.Gem),
 		GemFree: proto.Uint32(event.GemFree),
 	}
-	_, _, err := client.SendMessage(11503, &response)
+	_, _, err = client.SendMessage(11503, &response)
 	return err
-}
-
-func wasProcessedChargeEvent(commanderID uint32, payID string) bool {
-	chargeSuccessDedupMu.Lock()
-	defer chargeSuccessDedupMu.Unlock()
-	entries, ok := processedChargeEvents[commanderID]
-	if !ok {
-		return false
-	}
-	_, ok = entries[payID]
-	return ok
-}
-
-func markChargeEventProcessed(commanderID uint32, payID string) {
-	chargeSuccessDedupMu.Lock()
-	defer chargeSuccessDedupMu.Unlock()
-	entries, ok := processedChargeEvents[commanderID]
-	if !ok {
-		entries = map[string]struct{}{}
-		processedChargeEvents[commanderID] = entries
-	}
-	entries[payID] = struct{}{}
-}
-
-func resetChargeSuccessDedupForTest() {
-	chargeSuccessDedupMu.Lock()
-	defer chargeSuccessDedupMu.Unlock()
-	processedChargeEvents = map[uint32]map[string]struct{}{}
 }

--- a/internal/answer/charge_success_push_test.go
+++ b/internal/answer/charge_success_push_test.go
@@ -3,9 +3,16 @@ package answer
 import (
 	"testing"
 
+	"github.com/ggmolly/belfast/internal/connection"
+	"github.com/ggmolly/belfast/internal/orm"
 	"github.com/ggmolly/belfast/internal/protobuf"
 	"google.golang.org/protobuf/proto"
 )
+
+func resetChargeSuccessDedupForTest(t *testing.T) {
+	t.Helper()
+	clearTable(t, &orm.CommanderChargeSuccessEvent{})
+}
 
 func TestHandleChargeStartRemainsDisabled(t *testing.T) {
 	client := setupPlayerUpdateTest(t)
@@ -25,7 +32,7 @@ func TestHandleChargeStartRemainsDisabled(t *testing.T) {
 }
 
 func TestApplyChargeSuccessEventPushesSC11503(t *testing.T) {
-	resetChargeSuccessDedupForTest()
+	resetChargeSuccessDedupForTest(t)
 	client := setupPlayerUpdateTest(t)
 	event := ChargeSuccessEvent{ShopID: 10, PayID: "pay-001", Gem: 120, GemFree: 30}
 
@@ -44,7 +51,7 @@ func TestApplyChargeSuccessEventPushesSC11503(t *testing.T) {
 }
 
 func TestApplyChargeSuccessEventIdempotentByPayID(t *testing.T) {
-	resetChargeSuccessDedupForTest()
+	resetChargeSuccessDedupForTest(t)
 	client := setupPlayerUpdateTest(t)
 	event := ChargeSuccessEvent{ShopID: 22, PayID: "pay-dup", Gem: 40, GemFree: 10}
 
@@ -62,10 +69,26 @@ func TestApplyChargeSuccessEventIdempotentByPayID(t *testing.T) {
 	if len(packetIDs) != 1 || packetIDs[0] != 11503 {
 		t.Fatalf("expected a single SC_11503 packet, got %v", packetIDs)
 	}
+
+	reloadedCommander := orm.Commander{CommanderID: client.Commander.CommanderID}
+	if err := reloadedCommander.Load(); err != nil {
+		t.Fatalf("reload commander: %v", err)
+	}
+	reloadedClient := &connection.Client{Commander: &reloadedCommander}
+	if err := ApplyChargeSuccessEvent(reloadedClient.Commander, reloadedClient, event); err != nil {
+		t.Fatalf("duplicate charge success after reload: %v", err)
+	}
+	totalGems := queryAnswerTestInt64(t, "SELECT COALESCE(SUM(amount), 0) FROM owned_resources WHERE commander_id = $1 AND resource_id IN (4, 14)", int64(client.Commander.CommanderID))
+	if totalGems != 50 {
+		t.Fatalf("expected persistent idempotency across reload, got total gems %d", totalGems)
+	}
+	if reloadedClient.Buffer.Len() != 0 {
+		t.Fatalf("expected no push for duplicate event after reload")
+	}
 }
 
 func TestApplyChargeSuccessEventOfflineCommander(t *testing.T) {
-	resetChargeSuccessDedupForTest()
+	resetChargeSuccessDedupForTest(t)
 	client := setupPlayerUpdateTest(t)
 	event := ChargeSuccessEvent{ShopID: 42, PayID: "pay-offline", Gem: 80, GemFree: 20}
 
@@ -78,7 +101,7 @@ func TestApplyChargeSuccessEventOfflineCommander(t *testing.T) {
 }
 
 func TestApplyChargeSuccessEventRejectsMalformedInput(t *testing.T) {
-	resetChargeSuccessDedupForTest()
+	resetChargeSuccessDedupForTest(t)
 	client := setupPlayerUpdateTest(t)
 	if err := ApplyChargeSuccessEvent(client.Commander, client, ChargeSuccessEvent{ShopID: 0, PayID: "", Gem: 50, GemFree: 10}); err == nil {
 		t.Fatalf("expected malformed event error")

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -285,6 +285,12 @@ type CommanderBuff struct {
 	ExpiresAt   pgtype.Timestamptz
 }
 
+type CommanderChargeSuccessEvent struct {
+	CommanderID int64
+	PayID       string
+	CreatedAt   pgtype.Timestamptz
+}
+
 type CommanderColoringState struct {
 	CommanderID int64
 	ActivityID  int64

--- a/internal/db/migrations/0074_commander_charge_success_events.sql
+++ b/internal/db/migrations/0074_commander_charge_success_events.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS commander_charge_success_events (
+  commander_id bigint NOT NULL REFERENCES commanders(commander_id) ON DELETE CASCADE,
+  pay_id text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (commander_id, pay_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_commander_charge_success_events_commander_created
+  ON commander_charge_success_events (commander_id, created_at DESC);

--- a/internal/orm/commander_charge_success_event.go
+++ b/internal/orm/commander_charge_success_event.go
@@ -1,0 +1,28 @@
+package orm
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type CommanderChargeSuccessEvent struct {
+	CommanderID uint32
+	PayID       string
+}
+
+func (CommanderChargeSuccessEvent) TableName() string {
+	return "commander_charge_success_events"
+}
+
+func TryRecordChargeSuccessEventTx(ctx context.Context, tx pgx.Tx, commanderID uint32, payID string) (bool, error) {
+	result, err := tx.Exec(ctx, `
+INSERT INTO commander_charge_success_events (commander_id, pay_id)
+VALUES ($1, $2)
+ON CONFLICT (commander_id, pay_id) DO NOTHING
+`, int64(commanderID), payID)
+	if err != nil {
+		return false, err
+	}
+	return result.RowsAffected() == 1, nil
+}


### PR DESCRIPTION
# Summary
- Add a dedicated charge-success orchestration path that emits `SC_11503` with full payment success payload once settlement is known.
- Keep existing `CS_11501 -> SC_11502` disabled behavior unchanged while enabling asynchronous success handling for payment-complete events.

# Changes
- Introduced `ChargeSuccessEvent` and `ApplyChargeSuccessEvent` to apply gem rewards and emit `SC_11503`.
- Added pay-id idempotency tracking so repeated settlement events do not re-credit gems or send duplicate success pushes.
- Added malformed-event rejection and offline-commander handling (persist reward state without requiring an active client session).
- Added regression and behavior tests covering disabled charge-start response, success push payload, idempotency, offline flow, and invalid-event handling.
