### PR TITLE
fix(misc): skip missing ship templates in global build imports

### DIFF
--- a/internal/misc/update_data_sqlc.go
+++ b/internal/misc/update_data_sqlc.go
@@ -235,6 +235,7 @@ func importPoolsSQLC(ctx context.Context, region string, q *gen.Queries) error {
 	}
 	defer resp.Body.Close()
 	decoder.Token()
+	skippedMissingShips := 0
 	for decoder.More() {
 		var pool struct {
 			ID   uint32 `json:"id"`
@@ -251,8 +252,13 @@ func importPoolsSQLC(ctx context.Context, region string, q *gen.Queries) error {
 			return err
 		}
 		if tag.RowsAffected() == 0 {
-			return fmt.Errorf("ship not found for template_id=%d", pool.ID)
+			skippedMissingShips++
+			logger.LogEvent("GameData", "Updating", fmt.Sprintf("skipping pool mapping for missing ship template_id=%d (region=%s)", pool.ID, region), logger.LOG_LEVEL_WARN)
+			continue
 		}
+	}
+	if skippedMissingShips > 0 {
+		logger.LogEvent("GameData", "Updating", fmt.Sprintf("skipped %d pool mappings because ship templates were missing (region=%s)", skippedMissingShips, region), logger.LOG_LEVEL_WARN)
 	}
 	return nil
 }
@@ -285,23 +291,42 @@ func importBuildTimesSQLC(ctx context.Context, region string, q *gen.Queries) er
 	if err := decoder.Decode(&buildTimes); err != nil {
 		return err
 	}
+	skippedMissingShips, err := applyBuildTimes(buildTimes, func(templateID int64, buildTime int64) (int64, error) {
+		tag, err := q.SetShipBuildTime(ctx, gen.SetShipBuildTimeParams{
+			TemplateID: templateID,
+			BuildTime:  buildTime,
+		})
+		if err != nil {
+			return 0, err
+		}
+		return tag.RowsAffected(), nil
+	})
+	if err != nil {
+		return err
+	}
+	if skippedMissingShips > 0 {
+		logger.LogEvent("GameData", "Updating", fmt.Sprintf("skipped %d build times because ship templates were missing (region=%s)", skippedMissingShips, region), logger.LOG_LEVEL_WARN)
+	}
+	return nil
+}
+
+func applyBuildTimes(buildTimes map[string]uint32, setBuildTime func(templateID int64, buildTime int64) (int64, error)) (int, error) {
+	skippedMissingShips := 0
 	for id, timeValue := range buildTimes {
 		parsed, err := strconv.ParseInt(id, 10, 64)
 		if err != nil {
-			return err
+			return 0, err
 		}
-		tag, err := q.SetShipBuildTime(ctx, gen.SetShipBuildTimeParams{
-			TemplateID: parsed,
-			BuildTime:  int64(timeValue),
-		})
+		rowsAffected, err := setBuildTime(parsed, int64(timeValue))
 		if err != nil {
-			return err
+			return 0, err
 		}
-		if tag.RowsAffected() == 0 {
-			return fmt.Errorf("ship not found for template_id=%s", id)
+		if rowsAffected == 0 {
+			skippedMissingShips++
+			logger.LogEvent("GameData", "Updating", fmt.Sprintf("skipping build time for missing ship template_id=%s", id), logger.LOG_LEVEL_WARN)
 		}
 	}
-	return nil
+	return skippedMissingShips, nil
 }
 
 func importShopOffersSQLC(ctx context.Context, region string, q *gen.Queries) error {

--- a/internal/misc/update_data_sqlc_test.go
+++ b/internal/misc/update_data_sqlc_test.go
@@ -1,0 +1,28 @@
+package misc
+
+import "testing"
+
+func TestApplyBuildTimesSkipsMissingShipTemplate(t *testing.T) {
+	buildTimes := map[string]uint32{"10400031": 16200}
+
+	called := false
+	skipped, err := applyBuildTimes(buildTimes, func(templateID int64, buildTime int64) (int64, error) {
+		called = true
+		if templateID != 10400031 {
+			t.Fatalf("expected template id 10400031, got %d", templateID)
+		}
+		if buildTime != 16200 {
+			t.Fatalf("expected build time 16200, got %d", buildTime)
+		}
+		return 0, nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !called {
+		t.Fatalf("expected setBuildTime callback to be called")
+	}
+	if skipped != 1 {
+		t.Fatalf("expected one skipped template, got %d", skipped)
+	}
+}


### PR DESCRIPTION
# Summary
- Prevent startup data updates from failing when global build metadata references ship templates absent in the selected region.
- Keep region-specific ship datasets authoritative by skipping unmapped pool/build-time rows instead of aborting the transaction.
- Add regression coverage for template `10400031` to ensure missing-template handling stays non-fatal.

# Changes
- Updated `importPoolsSQLC` to warn and continue when `SetShipPoolID` affects zero rows.
- Refactored build-time application through `applyBuildTimes(...)` and made zero-row updates warn-and-skip.
- Added end-of-step warning summaries for skipped pool/build-time mappings.
- Added `TestApplyBuildTimesSkipsMissingShipTemplate` in `internal/misc/update_data_sqlc_test.go`.
